### PR TITLE
Small changes

### DIFF
--- a/framework/OpenMod.Core/Commands/CommandContext.cs
+++ b/framework/OpenMod.Core/Commands/CommandContext.cs
@@ -32,7 +32,7 @@ namespace OpenMod.Core.Commands
             Actor = parent.Actor;
             Parameters = new CommandParameters(this, parent.Parameters.Skip(1).ToList());
             CommandAlias = parent.Parameters[0];
-            CommandPrefix = $"{parent.CommandPrefix} {CommandAlias} ";
+            CommandPrefix = $"{parent.CommandPrefix}{parent.CommandAlias} ";
             Data = parent.Data;
         }
 

--- a/framework/OpenMod.Core/Commands/CommandWrongUsageException.cs
+++ b/framework/OpenMod.Core/Commands/CommandWrongUsageException.cs
@@ -12,7 +12,7 @@ namespace OpenMod.Core.Commands
             
         }
 
-        public CommandWrongUsageException(ICommandContext context, IStringLocalizer localizer) : base(localizer["commands:errors:wrong_usage", new { CommandLine = context.GetCommandLine(), CommandPrefix = context.CommandPrefix + context.CommandAlias, context.CommandRegistration.Syntax }])
+        public CommandWrongUsageException(ICommandContext context, IStringLocalizer localizer) : base(localizer["commands:errors:wrong_usage", new { CommandPrefix = (context.ParentContext != null ? context.ParentContext.CommandAlias : context.CommandAlias) + context.CommandPrefix, context.CommandRegistration.Syntax }])
         {
 
         }

--- a/framework/OpenMod.Core/Commands/CommandWrongUsageException.cs
+++ b/framework/OpenMod.Core/Commands/CommandWrongUsageException.cs
@@ -12,7 +12,7 @@ namespace OpenMod.Core.Commands
             
         }
 
-        public CommandWrongUsageException(ICommandContext context, IStringLocalizer localizer) : base(localizer["commands:errors:wrong_usage", new { CommandPrefix = (context.ParentContext != null ? context.ParentContext.CommandAlias : context.CommandAlias) + context.CommandPrefix, context.CommandRegistration.Syntax }])
+        public CommandWrongUsageException(ICommandContext context, IStringLocalizer localizer) : base(localizer["commands:errors:wrong_usage", new { CommandPrefix = context.CommandPrefix + context.CommandAlias, context.CommandRegistration.Syntax }])
         {
 
         }

--- a/framework/OpenMod.Core/Commands/OpenModCommands/CommandOpenModInstall.cs
+++ b/framework/OpenMod.Core/Commands/OpenModCommands/CommandOpenModInstall.cs
@@ -22,6 +22,11 @@ namespace OpenMod.Core.Commands.OpenModCommands
 
         protected override async Task OnExecuteAsync()
         {
+            if(Context.Parameters.Count == 0)
+            {
+                throw new CommandWrongUsageException(Context);
+            }
+
             var args = Context.Parameters.ToList();
 
             string packageName = Context.Parameters[0];

--- a/framework/OpenMod.Core/Commands/OpenModCommands/CommandOpenModUpdate.cs
+++ b/framework/OpenMod.Core/Commands/OpenModCommands/CommandOpenModUpdate.cs
@@ -22,6 +22,11 @@ namespace OpenMod.Core.Commands.OpenModCommands
 
         protected override async Task OnExecuteAsync()
         {
+            if(Context.Parameters.Count == 0)
+            {
+                throw new CommandWrongUsageException(Context);
+            }
+
             var args = Context.Parameters.ToList();
 
             string packageName = Context.Parameters[0];


### PR DESCRIPTION
- fix showing "correct" command usage when it is wrong.

Before:
.. add add <player>...

After:
.. pg add <player> ...


- fixed `om u` and `om i` when no args it throws IndexOutOfRange