### PR TITLE
Fix Sending Messages in Unturned

### DIFF
--- a/samples/UniversalSamplePlugin/UniversalSamplePlugin.cs
+++ b/samples/UniversalSamplePlugin/UniversalSamplePlugin.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenMod.Core.Plugins;
 
-[assembly: PluginMetadata("UnturnedSamplePlugin", Author = "OpenMod", DisplayName = "Unturned Sample Plugin")]
+[assembly: PluginMetadata("UniversalSamplePlugin", Author = "OpenMod", DisplayName = "Universal Sample Plugin")]
 
 namespace UniversalSamplePlugin
 {

--- a/unturned/OpenMod.Unturned/Users/UnturnedUser.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using OpenMod.API.Users;
 using OpenMod.Core.Users;
 using SDG.Unturned;
@@ -34,18 +35,18 @@ namespace OpenMod.Unturned.Users
             Session = new UnturnedUserSession(this, pending.Session);
         }
 
-        public override Task PrintMessageAsync(string message)
+        public override async Task PrintMessageAsync(string message)
         {
+            await UniTask.SwitchToMainThread();
             ChatManager.serverSendMessage(message, Color.white, toPlayer: SteamPlayer, mode: EChatMode.SAY, useRichTextFormatting: true);
-            return Task.CompletedTask;
         }
 
-        public override Task PrintMessageAsync(string message, System.Drawing.Color color)
+        public override async Task PrintMessageAsync(string message, System.Drawing.Color color)
         {
             var convertedColor = new Color(color.R / 255f, color.G / 255f, color.B / 255f);
 
+            await UniTask.SwitchToMainThread();
             ChatManager.serverSendMessage(message, convertedColor, toPlayer: SteamPlayer, mode: EChatMode.SAY, useRichTextFormatting: true);
-            return Task.CompletedTask;
         }
 
         public bool Equals(UnturnedUser other)


### PR DESCRIPTION
This ensures ChatManager.serverSendMessage() is sent from the main thread, otherwise it will error. UniversalSamplePlugin.cs is unrelated.

I am unfamiliar with UniTask, maybe it's necessary to switch back to thread pool afterwards?

Traceback:
```
[2020-06-26 15:54:01 ERR][] Exception occured in task "Player command execution"
System.NotSupportedException: This function should only be called from the game thread. (e.g. from Unity's Update)
  at SDG.Unturned.ThreadUtil.assertIsGameThread () [0x0000c] in <583092d77ee44d62b65636564269a567>:0 
  at SDG.Unturned.ChatManager.serverSendMessage (System.String text, UnityEngine.Color color, SDG.Unturned.SteamPlayer fromPlayer, SDG.Unturned.SteamPlayer toPlayer, SDG.Unturned.EChatMode mode, System.String iconURL, System.Boolean useRichTextFormatting) [0x00018] in <583092d77ee44d62b65636564269a567>:0 
  at OpenMod.Unturned.Users.UnturnedUser+<PrintMessageAsync>d__13.MoveNext () [0x00052] in <8e15d5b2635d4a4c8e4efa9e02b707ab>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Core.Commands.CommandExecutor+<ExecuteAsync>d__6.MoveNext () [0x00519] in <94ce5c7ace554dda8fa86e4682dd6be7>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Core.Commands.CommandExecutor+<ExecuteAsync>d__6.MoveNext () [0x006d9] in <94ce5c7ace554dda8fa86e4682dd6be7>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Unturned.Users.UnturnedCommandHandler+<>c__DisplayClass6_0+<<OnCheckCommandPermissions>b__0>d.MoveNext () [0x00125] in <8e15d5b2635d4a4c8e4efa9e02b707ab>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Core.Helpers.AsyncHelper+<>c__DisplayClass5_0+<<Schedule>b__0>d.MoveNext () [0x0006d] in <94ce5c7ace554dda8fa86e4682dd6be7>:0 
```