### PR TITLE
Fix OfflineUserProvider when user doesn't exists

### DIFF
--- a/framework/OpenMod.Core/Users/OfflineUserProvider.cs
+++ b/framework/OpenMod.Core/Users/OfflineUserProvider.cs
@@ -29,6 +29,11 @@ namespace OpenMod.Core.Users
             }
 
             var data = await m_UserDataStore.GetUserDataAsync(searchString, userType);
+            if (data == null)
+            {
+            	return null;
+            }
+            
             return new OfflineUser(m_UserDataStore, data);
         }
 


### PR DESCRIPTION
```
Exception occured on command "balance asd" by actor console/Console (openmod-unturned-console)
System.NullReferenceException: Object reference not set to an instance of an object
  at OpenMod.Core.Users.OfflineUser..ctor (OpenMod.API.Users.IUserDataStore userDataStore, OpenMod.API.Users.UserData data) [0x00007] in <405ae8bb4571464eabafde1aeb743e78>:0 
  at OpenMod.Core.Users.OfflineUserProvider+<FindUserAsync>d__3.MoveNext () [0x00096] in <405ae8bb4571464eabafde1aeb743e78>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Core.Users.UserManager+<FindUserAsync>d__5.MoveNext () [0x000f2] in <405ae8bb4571464eabafde1aeb743e78>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Economy.Commands.CommandBalance+<OnExecuteAsync>d__5.MoveNext () [0x001dc] in <022dcaa5ab5345ac829f4d25f937d18b>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at OpenMod.Core.Commands.CommandExecutor+<ExecuteAsync>d__6.MoveNext () [0x003a5] in <405ae8bb4571464eabafde1aeb743e78>:0 
```