### PR TITLE
Throw User Friendly Exceptions For Bad Actors

### DIFF
--- a/framework/OpenMod.Core/openmod.translations.yaml
+++ b/framework/OpenMod.Core/openmod.translations.yaml
@@ -6,3 +6,4 @@
     parse_error: "Parse error: could not parse {Value} to {Type.Name}"
     not_found: "Command was not found: {CommandName}"
     wrong_usage: "Wrong command usage. Correct usage: {Command} {Syntax}"
+    bad_actor: "{CommandName} cannot be executed by: {ActorType}"


### PR DESCRIPTION
Right now when a command is executed by an actor that is not supported, a command not found exception is thrown. This is misleading and can cause confusion.

This PR makes commands throw a more informative user friendly exception instead. There might be a better way to do it but I have tested this and it is working.