### PR TITLE
Fix some exceptions

### DIFF
--- a/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenMod.API;
@@ -85,7 +84,10 @@ namespace OpenMod.Unturned.Users
         {
             AsyncHelper.RunSync(() =>
             {
-                var pending = m_PendingUsers.First(d => d.SteamId == player.playerID.steamID);
+                var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == player.playerID.steamID);
+                if (pending == null)
+                    return Task.CompletedTask;
+
                 FinishSession(pending);
 
                 var user = new UnturnedUser(m_UserDataStore, player.player, pending);
@@ -96,11 +98,13 @@ namespace OpenMod.Unturned.Users
             });
         }
 
-        protected virtual void OnRejectingPlayer(CSteamID steamID, ESteamRejection rejection, string explanation)
+        protected virtual void OnRejectingPlayer(CSteamID steamId, ESteamRejection rejection, string explanation)
         {
             AsyncHelper.RunSync(async () =>
             {
-                var pending = m_PendingUsers.First(d => d.SteamId == steamID);
+                var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == steamId);
+                if (pending == null)
+                    return;
 
                 var disconnectedEvent = new UserDisconnectedEvent(pending);
                 await m_EventBus.EmitAsync(m_Runtime, this, disconnectedEvent);
@@ -126,7 +130,11 @@ namespace OpenMod.Unturned.Users
 
             AsyncHelper.RunSync(async () =>
             {
-                var steamPending = Provider.pending.First(d => d.playerID.steamID == callback.m_SteamID);
+                var steamPending = Provider.pending.FirstOrDefault(d => d.playerID.steamID == callback.m_SteamID);
+                if (steamPending == null)
+                    return;
+
+
                 var pendingUser = new UnturnedPendingUser(m_UserDataStore, steamPending);
                 await m_DataSeeder.SeedUserDataAsync(pendingUser.Id, pendingUser.Type, pendingUser.DisplayName);
 


### PR DESCRIPTION
Exception example:

```
[2020-06-29 15:07:58 WRN][SDG.Unturned] Sequence contains no matching element
[2020-06-29 15:07:58 WRN][SDG.Unturned]   at System.Linq.Enumerable.First[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00011] in <fbb5ed17eb6e46c680000f8910ebb50c>:0 
  at OpenMod.Unturned.Users.UnturnedUserProvider+<>c__DisplayClass12_0+<<OnRejectingPlayer>b__0>d.MoveNext () [0x00020] in <e6c488449c9044a3ab25975735fbb144>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException (System.Threading.Tasks.Task task) [0x00015] in <e609703832c1447ba57019bc973cc564>:0 
  at Nito.AsyncEx.AsyncContext+<>c__DisplayClass15_0.<Run>b__0 (System.Threading.Tasks.Task t) [0x0000b] in <15f79df01f394725ba0a0a0856096654>:0 
  at System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke () [0x00024] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Threading.Tasks.Task.Execute () [0x00010] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0 
  at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException (System.Threading.Tasks.Task task) [0x00015] in <e609703832c1447ba57019bc973cc564>:0 
  at Nito.AsyncEx.AsyncContext.Run (System.Func`1[TResult] action) [0x0006c] in <15f79df01f394725ba0a0a0856096654>:0 
  at OpenMod.Core.Helpers.AsyncHelper.RunSync (System.Func`1[TResult] action) [0x00000] in <08037b11389f4e15a02936704a939eb2>:0 
  at OpenMod.Unturned.Users.UnturnedUserProvider.OnRejectingPlayer (Steamworks.CSteamID steamID, SDG.Unturned.ESteamRejection rejection, System.String explanation) [0x00005] in <e6c488449c9044a3ab25975735fbb144>:0 
  at SDG.Unturned.Provider.broadcastRejectingPlayer (Steamworks.CSteamID steamID, SDG.Unturned.ESteamRejection rejection, System.String explanation) [0x00009] in <583092d77ee44d62b65636564269a567>:0 
```