### PR TITLE
Fixes 'Player not found' error

### DIFF
--- a/framework/OpenMod.Core/Commands/OpenModCommands/CommandPermissionAction.cs
+++ b/framework/OpenMod.Core/Commands/OpenModCommands/CommandPermissionAction.cs
@@ -54,7 +54,7 @@ namespace OpenMod.Core.Commands.OpenModCommands
                 case "player":
                     permission = "Manage.Players";
                     var id = await Context.Parameters.GetAsync<string>(1);
-                    var user = await m_UserDataStore.GetUserDataAsync(id, actorType);
+                    var user = await m_UserDataStore.GetUserDataAsync(id, "player");
 
                     if (user == null)
                     {


### PR DESCRIPTION
Whenever the argument "p" is used in place of "player", "p" is passed on as the `userType` argument, resulting in the user not being found.