### PR TITLE
Add obsolete attribute

### DIFF
--- a/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
+++ b/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
@@ -9,6 +9,8 @@ namespace OpenMod.Core.Localization
     [OpenModInternal]
     public class ConfigurationBasedStringLocalizerFactory : IStringLocalizerFactory
     {
+    
+        [Obsolete("Use Create(baseName, location)")]
         public IStringLocalizer Create(Type resourceSource)
         {
             throw new NotSupportedException("Please use Create(baseName, location) instead!");


### PR DESCRIPTION
If I remember correctly this is better with IDEs, so users can actually find this out at compile time instead of getting an exception at runtime