### PR TITLE
Fix some async/await warnings

### DIFF
--- a/framework/OpenMod.Core/Commands/CommandParameters.cs
+++ b/framework/OpenMod.Core/Commands/CommandParameters.cs
@@ -41,7 +41,7 @@ namespace OpenMod.Core.Commands
         public async Task<T> GetAsync<T>(int index) => (T)await GetAsync(index, typeof(T));
 
         /// <inheritdoc />
-        public async Task<object> GetAsync(int index, Type type)
+        public Task<object> GetAsync(int index, Type type)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
@@ -55,8 +55,6 @@ namespace OpenMod.Core.Commands
                 throw new IndexOutOfRangeException();
 
             string arg = ToArray()[index];
-
-
 
             //todo make type converters
             //if (typeof(IUser).IsAssignableFrom(type))
@@ -93,7 +91,8 @@ namespace OpenMod.Core.Commands
             {
                 try
                 {
-                    return converter.ConvertFromWithServiceContext(m_ServiceProvider, arg);
+                    object paramValue = converter.ConvertFromWithServiceContext(m_ServiceProvider, arg);
+                    return Task.FromResult(paramValue);
                 }
                 catch (Exception ex)
                 {
@@ -111,11 +110,12 @@ namespace OpenMod.Core.Commands
         public async Task<T> GetAsync<T>(int index, T defaultValue) => (T)await GetAsync(index, typeof(T), defaultValue);
 
         /// <inheritdoc />
-        public async Task<object> GetAsync(int index, Type type, object defaultValue)
+        public Task<object> GetAsync(int index, Type type, object defaultValue)
         {
             if (TryGet(index, type, out object val))
-                return val;
-            return defaultValue;
+                return Task.FromResult(val);
+
+            return Task.FromResult(defaultValue);
         }
 
         /// <inheritdoc />

--- a/framework/OpenMod.Core/Commands/MethodCommandWrapper.cs
+++ b/framework/OpenMod.Core/Commands/MethodCommandWrapper.cs
@@ -17,7 +17,8 @@ namespace OpenMod.Core.Commands
         {
             m_MethodInfo = methodInfo;
         }
-        public async Task ExecuteAsync()
+
+        public Task ExecuteAsync()
         {
             // todo: implement MethodCommandWrapper
             throw new NotImplementedException();

--- a/framework/OpenMod.Core/Plugins/OpenModUniversalPlugin.cs
+++ b/framework/OpenMod.Core/Plugins/OpenModUniversalPlugin.cs
@@ -9,10 +9,10 @@ namespace OpenMod.Core.Plugins
         {
         }
 
-        public sealed override Task LoadAsync()
+        public sealed override async Task LoadAsync()
         {
-            base.LoadAsync();
-            return OnLoadAsync();
+            await base.LoadAsync();
+            await OnLoadAsync();
         }
 
         protected virtual Task OnLoadAsync()
@@ -20,10 +20,10 @@ namespace OpenMod.Core.Plugins
             return Task.CompletedTask;
         }
 
-        public sealed override Task UnloadAsync()
+        public sealed override async Task UnloadAsync()
         {
-            base.UnloadAsync();
-            return OnUnloadAsync();
+            await base.UnloadAsync();
+            await OnUnloadAsync();
         }
 
         protected virtual Task OnUnloadAsync()


### PR DESCRIPTION
- CS1998: This async method lacks 'await' operators and will run synchronously.
- CS4014: Because this call is not awaited, execution of the current method continues before the call is completed.