### PR TITLE
Add color-less BroadcastAsync methods

### DIFF
--- a/framework/OpenMod.API/Users/IUserManager.cs
+++ b/framework/OpenMod.API/Users/IUserManager.cs
@@ -14,6 +14,10 @@ namespace OpenMod.API.Users
 
         Task<IUser> FindUserAsync(string type, string searchString, UserSearchMode searchMode);
 
+        Task BroadcastAsync(string message);
+
+        Task BroadcastAsync(string userType, string message);
+
         Task BroadcastAsync(string message, Color color);
 
         Task BroadcastAsync(string userType, string message, Color color);

--- a/framework/OpenMod.API/Users/IUserManager.cs
+++ b/framework/OpenMod.API/Users/IUserManager.cs
@@ -14,12 +14,8 @@ namespace OpenMod.API.Users
 
         Task<IUser> FindUserAsync(string type, string searchString, UserSearchMode searchMode);
 
-        Task BroadcastAsync(string message);
+        Task BroadcastAsync(string message, Color? color = null);
 
-        Task BroadcastAsync(string userType, string message);
-
-        Task BroadcastAsync(string message, Color color);
-
-        Task BroadcastAsync(string userType, string message, Color color);
+        Task BroadcastAsync(string userType, string message, Color? color = null);
     }
 }

--- a/framework/OpenMod.API/Users/IUserProvider.cs
+++ b/framework/OpenMod.API/Users/IUserProvider.cs
@@ -12,12 +12,8 @@ namespace OpenMod.API.Users
 
         Task<IReadOnlyCollection<IUser>> GetUsersAsync(string userType);
 
-        Task BroadcastAsync(string userType, string message, Color color);
+        Task BroadcastAsync(string userType, string message, Color? color = null);
         
-        Task BroadcastAsync(string message, Color color);
-
-        Task BroadcastAsync(string userType, string message);
-
-        Task BroadcastAsync(string message);
+        Task BroadcastAsync(string message, Color? color = null);
     }
 }

--- a/framework/OpenMod.API/Users/IUserProvider.cs
+++ b/framework/OpenMod.API/Users/IUserProvider.cs
@@ -15,5 +15,9 @@ namespace OpenMod.API.Users
         Task BroadcastAsync(string userType, string message, Color color);
         
         Task BroadcastAsync(string message, Color color);
+
+        Task BroadcastAsync(string userType, string message);
+
+        Task BroadcastAsync(string message);
     }
 }

--- a/framework/OpenMod.Core/Users/OfflineUserProvider.cs
+++ b/framework/OpenMod.Core/Users/OfflineUserProvider.cs
@@ -44,22 +44,12 @@ namespace OpenMod.Core.Users
             return userDatas.Select(d => new OfflineUser(m_UserDataStore, d)).ToList();
         }
 
-        public Task BroadcastAsync(string userType, string message, Color color)
+        public Task BroadcastAsync(string userType, string message, Color? color)
         {
             return Task.CompletedTask;
         }
 
-        public Task BroadcastAsync(string message, Color color)
-        {
-            return Task.CompletedTask;
-        }
-
-        public Task BroadcastAsync(string userType, string message)
-        {
-            return Task.CompletedTask;
-        }
-
-        public Task BroadcastAsync(string message)
+        public Task BroadcastAsync(string message, Color? color)
         {
             return Task.CompletedTask;
         }

--- a/framework/OpenMod.Core/Users/OfflineUserProvider.cs
+++ b/framework/OpenMod.Core/Users/OfflineUserProvider.cs
@@ -53,5 +53,15 @@ namespace OpenMod.Core.Users
         {
             return Task.CompletedTask;
         }
+
+        public Task BroadcastAsync(string userType, string message)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastAsync(string message)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/framework/OpenMod.Core/Users/UserManager.cs
+++ b/framework/OpenMod.Core/Users/UserManager.cs
@@ -61,6 +61,25 @@ namespace OpenMod.Core.Users
             return null;
         }
 
+        public virtual async Task BroadcastAsync(string message)
+        {
+            foreach (var provider in UserProviders)
+            {
+                await provider.BroadcastAsync(message);
+            }
+        }
+
+        public virtual async Task BroadcastAsync(string userType, string message)
+        {
+            var provider = UserProviders.FirstOrDefault(d => d.SupportsUserType(userType));
+            if (provider == null)
+            {
+                return;
+            }
+
+            await provider.BroadcastAsync(userType, message);
+        }
+
         public virtual async Task BroadcastAsync(string message, Color color)
         {
             foreach (var provider in UserProviders)

--- a/framework/OpenMod.Core/Users/UserManager.cs
+++ b/framework/OpenMod.Core/Users/UserManager.cs
@@ -80,7 +80,7 @@ namespace OpenMod.Core.Users
             await provider.BroadcastAsync(userType, message);
         }
 
-        public virtual async Task BroadcastAsync(string message, Color color)
+        public virtual async Task BroadcastAsync(string message, Color? color)
         {
             foreach (var provider in UserProviders)
             {
@@ -88,7 +88,7 @@ namespace OpenMod.Core.Users
             }
         }
 
-        public virtual async Task BroadcastAsync(string userType, string message, Color color)
+        public virtual async Task BroadcastAsync(string userType, string message, Color? color)
         {
             var provider = UserProviders.FirstOrDefault(d => d.SupportsUserType(userType));
             if (provider == null)

--- a/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
@@ -312,6 +312,21 @@ namespace OpenMod.Unturned.Users
             return BroadcastTask().AsTask();
         }
 
+        public Task BroadcastAsync(string userType, string message)
+        {
+            if (!KnownActorTypes.Player.Equals(userType, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            return BroadcastAsync(message, System.Drawing.Color.White);
+        }
+
+        public Task BroadcastAsync(string message)
+        {
+            return BroadcastAsync(message, System.Drawing.Color.White);
+        }
+
         public void Dispose()
         {
             m_UnturnedUsers.Clear();

--- a/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
@@ -291,7 +291,7 @@ namespace OpenMod.Unturned.Users
             return Task.FromResult<IReadOnlyCollection<IUser>>(m_UnturnedUsers);
         }
 
-        public Task BroadcastAsync(string userType, string message, System.Drawing.Color color)
+        public Task BroadcastAsync(string userType, string message, System.Drawing.Color? color)
         {
             if (!KnownActorTypes.Player.Equals(userType, StringComparison.OrdinalIgnoreCase))
             {
@@ -301,30 +301,18 @@ namespace OpenMod.Unturned.Users
             return BroadcastAsync(message, color);
         }
 
-        public Task BroadcastAsync(string message, System.Drawing.Color color)
+        public Task BroadcastAsync(string message, System.Drawing.Color? color)
         {
             async UniTask BroadcastTask()
             {
                 await UniTask.SwitchToMainThread();
-                ChatManager.serverSendMessage(text: message, color: new Color(color.R / 255f, color.G / 255f, color.B / 255f), useRichTextFormatting: true);
+
+                color ??= System.Drawing.Color.White;
+
+                ChatManager.serverSendMessage(text: message, color: new Color(color.Value.R / 255f, color.Value.G / 255f, color.Value.B / 255f), useRichTextFormatting: true);
             }
 
             return BroadcastTask().AsTask();
-        }
-
-        public Task BroadcastAsync(string userType, string message)
-        {
-            if (!KnownActorTypes.Player.Equals(userType, StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.CompletedTask;
-            }
-
-            return BroadcastAsync(message, System.Drawing.Color.White);
-        }
-
-        public Task BroadcastAsync(string message)
-        {
-            return BroadcastAsync(message, System.Drawing.Color.White);
         }
 
         public void Dispose()


### PR DESCRIPTION
Added `BroadcastAsync(string message)` and `BroadcastAsync(string userType, string message)` to `IUserProvider` and `IUserManager`.
This will allow plugins to just send a message if they chose to not deal with colors.