### PR TITLE
Pass balance on NotEnoughBalanceExcetion

### DIFF
--- a/extensions/OpenMod.Extensions.Economy.Abstractions/NotEnoughBalanceException.cs
+++ b/extensions/OpenMod.Extensions.Economy.Abstractions/NotEnoughBalanceException.cs
@@ -4,8 +4,15 @@ namespace OpenMod.Extensions.Economy.Abstractions
 {
     public class NotEnoughBalanceException : UserFriendlyException
     {
+        public decimal? Balance = null;
+
         public NotEnoughBalanceException(string message) : base(message)
         {
+        }
+
+        public NotEnoughBalanceException(string message, decimal balance) : base(message)
+        {
+            Balance = balance;
         }
     }
 }


### PR DESCRIPTION
I can't understand why it says that CommandOpenModInstall.cs is different from the source