### PR TITLE
Fixes infinite loop and abstract events emitting

### DIFF
--- a/framework/OpenMod.Core/Eventing/Event.cs
+++ b/framework/OpenMod.Core/Eventing/Event.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace OpenMod.Core.Eventing
 {
-    public class Event : EventBase
+    public abstract class Event : EventBase
     {
         public override Dictionary<string, object> Arguments
         {

--- a/framework/OpenMod.Core/Eventing/EventBus.cs
+++ b/framework/OpenMod.Core/Eventing/EventBus.cs
@@ -145,7 +145,7 @@ namespace OpenMod.Core.Eventing
             }
 
             var currentType = @event.GetType();
-            while (currentType != null && typeof(IEvent).IsAssignableFrom(currentType))
+            while (currentType != null && !currentType.IsAbstract && typeof(IEvent).IsAssignableFrom(currentType))
             {
                 string eventName = GetEventName(currentType);
 
@@ -165,6 +165,8 @@ namespace OpenMod.Core.Eventing
 
                 if (eventSubscriptions.Count == 0)
                 {
+                    currentType = currentType.BaseType;
+
                     m_Logger?.LogTrace($"{eventName}: No listeners found.");
                     continue;
                 }
@@ -218,10 +220,10 @@ namespace OpenMod.Core.Eventing
                             m_Logger.LogError(ex, $"Exception occured during event {@eventName}");
                         }
                     }
-
-                    currentType = currentType.BaseType;
                 }
-         
+
+                currentType = currentType.BaseType;
+
                 Complete();
             }
 


### PR DESCRIPTION
Abstract events should not be emitted. In the logs, this also gets confusing as you'll see behaviour like this:
```
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] Emitting event: OpenModInitialized
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] OpenModInitialized: No listeners found.
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] Emitting event:
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] : No listeners found.
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] Emitting event: Base
[23:09:28 VRB][OpenMod.Core.Eventing.EventBus] Base: No listeners found.
```

Also fixes moving on to the base type prematurely when emitting events.