### PR TITLE
Fix check player permission when user is no seeded

### DIFF
--- a/framework/OpenMod.Core/Permissions/DefaultPermissionRoleStore.cs
+++ b/framework/OpenMod.Core/Permissions/DefaultPermissionRoleStore.cs
@@ -59,7 +59,9 @@ namespace OpenMod.Core.Permissions
 
             var userData = await m_UserDataStore.GetUserDataAsync(actor.Id, actor.Type);
             if (userData == null)
-                return roles;
+            {
+                return GetAutoAssignRoles().ToList();
+            }
 
             // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
             foreach (var roleId in userData.Roles)

--- a/framework/OpenMod.Core/Permissions/DefaultPermissionRoleStore.cs
+++ b/framework/OpenMod.Core/Permissions/DefaultPermissionRoleStore.cs
@@ -9,9 +9,7 @@ using OpenMod.API.Ioc;
 using OpenMod.API.Permissions;
 using OpenMod.API.Prioritization;
 using OpenMod.API.Users;
-using OpenMod.Core.Helpers;
 using OpenMod.Core.Permissions.Data;
-using OpenMod.Core.Users;
 
 namespace OpenMod.Core.Permissions
 {
@@ -60,6 +58,9 @@ namespace OpenMod.Core.Permissions
             }
 
             var userData = await m_UserDataStore.GetUserDataAsync(actor.Id, actor.Type);
+            if (userData == null)
+                return roles;
+
             // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
             foreach (var roleId in userData.Roles)
             {


### PR DESCRIPTION
if a player's permissions need to be checked before he is seeded