### PR TITLE
Fix an issue with destroying buildables in unturned

### DIFF
--- a/unturned/OpenMod.Unturned/Building/UnturnedBarricadeBuildable.cs
+++ b/unturned/OpenMod.Unturned/Building/UnturnedBarricadeBuildable.cs
@@ -32,7 +32,11 @@ namespace OpenMod.Unturned.Building
             async UniTask DestroyTask()
             {
                 await UniTask.SwitchToMainThread();
-                Object.Destroy(Interactable);
+
+                if (BarricadeManager.tryGetInfo(BarricadeDrop.model, out var x, out var y, out var plant, out var index, out var region))
+                {
+                    BarricadeManager.destroyBarricade(region, x, y, plant, index);
+                }
             }
 
             return DestroyTask().AsTask();

--- a/unturned/OpenMod.Unturned/Building/UnturnedStructureBuildable.cs
+++ b/unturned/OpenMod.Unturned/Building/UnturnedStructureBuildable.cs
@@ -2,6 +2,7 @@
 using OpenMod.UnityEngine.Transforms;
 using SDG.Unturned;
 using System.Threading.Tasks;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace OpenMod.Unturned.Building
@@ -28,7 +29,11 @@ namespace OpenMod.Unturned.Building
             async UniTask DestroyTask()
             {
                 await UniTask.SwitchToMainThread();
-                Object.Destroy(StructureDrop.model);
+
+                if (StructureManager.tryGetInfo(StructureDrop.model, out var x, out var y, out var index, out var region))
+                {
+                    StructureManager.destroyStructure(region, x, y, index, Vector3.zero);
+                }
             }
 
             return DestroyTask().AsTask();


### PR DESCRIPTION
As discussed on discord, the destroy methods for buildables should call the manager's respective destroy methods, as otherwise no replication is done.
Fixes #199 