### PR TITLE
Delayed UnturnedUser and UnturnedPlayer connected events by one frame

### DIFF
--- a/unturned/OpenMod.Unturned/Players/Connections/Events/PlayerConnectionsEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Connections/Events/PlayerConnectionsEventsListener.cs
@@ -1,4 +1,5 @@
-﻿using OpenMod.API;
+﻿using Cysharp.Threading.Tasks;
+using OpenMod.API;
 using OpenMod.API.Eventing;
 using OpenMod.API.Users;
 using OpenMod.Unturned.Events;
@@ -29,11 +30,18 @@ namespace OpenMod.Unturned.Players.Connections.Events
 
         private void OnPlayerConnected(SteamPlayer steamPlayer)
         {
-            UnturnedPlayer player = GetUnturnedPlayer(steamPlayer);
+            async UniTaskVoid EmitPlayerConnected(SteamPlayer nativePlayer)
+            {
+                UnturnedPlayer player = GetUnturnedPlayer(nativePlayer);
 
-            UnturnedPlayerConnectedEvent @event = new UnturnedPlayerConnectedEvent(player);
+                await UniTask.DelayFrame(1);
 
-            Emit(@event);
+                UnturnedPlayerConnectedEvent @event = new UnturnedPlayerConnectedEvent(player);
+
+                Emit(@event);
+            }
+
+            EmitPlayerConnected(steamPlayer).Forget();
         }
 
         private void OnPlayerDisconnected(SteamPlayer steamPlayer)

--- a/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
@@ -82,7 +82,14 @@ namespace OpenMod.Unturned.Users
 
             var connectedEvent = new UnturnedUserConnectedEvent(user);
 
-            AsyncHelper.RunSync(() => m_EventBus.EmitAsync(m_Runtime, this, connectedEvent));
+            async UniTaskVoid EmitDelayedEvent(UnturnedUserConnectedEvent @event)
+            {
+                await UniTask.DelayFrame(1);
+
+                await m_EventBus.EmitAsync(m_Runtime, this, connectedEvent);
+            }
+
+            EmitDelayedEvent(connectedEvent).Forget();
         }
 
         protected virtual void OnPlayerDisconnected(SteamPlayer steamPlayer)


### PR DESCRIPTION
Fixes bugs where not all Unity components are started and ready to be accessed by methods subscribing to events.