### PR TITLE
Fixes abstract base types of events not emitting

### DIFF
--- a/framework/OpenMod.Core/Eventing/EventBus.cs
+++ b/framework/OpenMod.Core/Eventing/EventBus.cs
@@ -155,7 +155,8 @@ namespace OpenMod.Core.Eventing
             var eventTypes = new List<Type>();
 
             var currentType = @event.GetType();
-            while (currentType != null && !currentType.IsAbstract && !currentType.IsInterface && typeof(IEvent).IsAssignableFrom(currentType))
+
+            while (currentType != null && typeof(IEvent).IsAssignableFrom(currentType))
             {
                 eventTypes.Add(currentType);
                 currentType = currentType.BaseType;


### PR DESCRIPTION
Also removes unnecessary check if base type is an interface, as `Type.BaseType` never returns an interface.