### PR TITLE
Added standardized TimeSpan string parser

### DIFF
--- a/framework/OpenMod.Core/Commands/Parameters/TimeSpanCommandParameterResolveProvider.cs
+++ b/framework/OpenMod.Core/Commands/Parameters/TimeSpanCommandParameterResolveProvider.cs
@@ -1,10 +1,12 @@
 ﻿using OpenMod.API.Commands;
+using OpenMod.API.Prioritization;
 using OpenMod.Core.Helpers;
 using System;
 using System.Threading.Tasks;
 
 namespace OpenMod.Core.Commands.Parameters
 {
+    [Priority(Priority = Priority.Low)]
     public class TimeSpanCommandParameterResolveProvider : ICommandParameterResolveProvider
     {
         public bool Supports(Type type)

--- a/framework/OpenMod.Core/Commands/Parameters/TimeSpanCommandParameterResolveProvider.cs
+++ b/framework/OpenMod.Core/Commands/Parameters/TimeSpanCommandParameterResolveProvider.cs
@@ -1,0 +1,25 @@
+﻿using OpenMod.API.Commands;
+using OpenMod.Core.Helpers;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenMod.Core.Commands.Parameters
+{
+    public class TimeSpanCommandParameterResolveProvider : ICommandParameterResolveProvider
+    {
+        public bool Supports(Type type)
+        {
+            return typeof(TimeSpan) == type;
+        }
+
+        public Task<object> ResolveAsync(Type type, string input)
+        {
+            if (!Supports(type))
+            {
+                throw new ArgumentException("The given type is not supported", nameof(type));
+            }
+
+            return Task.FromResult((object)TimeSpanHelper.Parse(input));
+        }
+    }
+}

--- a/framework/OpenMod.Core/Helpers/TimeSpanHelper.cs
+++ b/framework/OpenMod.Core/Helpers/TimeSpanHelper.cs
@@ -1,0 +1,94 @@
+﻿using OpenMod.API.Commands;
+using System;
+using System.Text.RegularExpressions;
+
+namespace OpenMod.Core.Helpers
+{
+    public static class TimeSpanHelper
+    {
+        /**
+         * Regex Breakdown:
+         * (\d+\.?\d*|\d*\.?\d+)\ *[a-zA-Z]+
+         *  \d+\.?\d*                           Must start with one or more digits, then match can include a period, then match can end with zero or more digits
+         *           |                          or
+         *            \d*\.?\d+                 Starts with zero or more digits, then match can include a period, then match must end with one or more digits
+         *                      \ *             Can contain spaces
+         *                         [a-zA-Z]+    One or more letters
+         */
+        private static readonly Regex s_RegexPattern = new Regex(@"(\d+\.?\d*|\d*\.?\d+)\ *[a-zA-Z]+");
+
+        /**
+         * Examples of unparsed inputs:
+         * - 20 seconds
+         * - 30 days, 40 minutes, and 50 seconds
+         * - 10h20m30s
+         * - 3.5 days
+         * - 1234.123     milliseconds
+         */
+        public static TimeSpan Parse(string unparsed)
+        {
+            var matches = s_RegexPattern.Matches(unparsed);
+
+            TimeSpan total = new TimeSpan();
+
+            if (matches.Count == 0)
+            {
+                throw new UserFriendlyException("Invalid time span format");
+            }
+
+            foreach (Match match in matches)
+            {
+                string value = match.Value;
+
+                int i;
+
+                for (i = 0; i < value.Length; i++)
+                {
+                    if ((value[i] < '0' || value[i] > '9') && value[i] != '.') break;
+                }
+
+                double num = double.Parse(value.Substring(0, i));
+                string suffix = value.Substring(i).Trim();
+
+                switch (suffix.ToLower())
+                {
+                    case "d":
+                    case "day":
+                    case "days":
+                        total += TimeSpan.FromDays(num);
+                        break;
+                    case "h":
+                    case "hr":
+                    case "hrs":
+                    case "hour":
+                    case "hours":
+                        total += TimeSpan.FromHours(num);
+                        break;
+                    case "m":
+                    case "min":
+                    case "mins":
+                    case "minute":
+                    case "minutes":
+                        total += TimeSpan.FromMinutes(num);
+                        break;
+                    case "s":
+                    case "sec":
+                    case "secs":
+                    case "second":
+                    case "seconds":
+                        total += TimeSpan.FromSeconds(num);
+                        break;
+                    case "ms":
+                    case "milli":
+                    case "millis":
+                    case "millisecond":
+                    case "milliseconds":
+                        total += TimeSpan.FromMilliseconds(num);
+                        break;
+                }
+            }
+
+            return total;
+        }
+    }
+}

--- a/framework/OpenMod.Core/ServiceConfigurator.cs
+++ b/framework/OpenMod.Core/ServiceConfigurator.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenMod.API.Ioc;
 using OpenMod.API.Plugins;
 using OpenMod.Core.Commands;
+using OpenMod.Core.Commands.Parameters;
 using OpenMod.Core.Console;
 using OpenMod.Core.Localization;
 using OpenMod.Core.Permissions;
 using OpenMod.Core.Plugins;
 using OpenMod.Core.Users;
+using System;
 
 namespace OpenMod.Core
 {
@@ -41,6 +42,7 @@ namespace OpenMod.Core
             {
                 options.AddCommandParameterResolveProvider<TypeDescriptorCommandParameterResolveProvider>();
                 options.AddCommandParameterResolveProvider<UserCommandParameterResolveProvider>();
+                options.AddCommandParameterResolveProvider<TimeSpanCommandParameterResolveProvider>();
             });
 
             serviceCollection.AddTransient<IStringLocalizerFactory, ConfigurationBasedStringLocalizerFactory>();


### PR DESCRIPTION
Also added TimeSpan parameter resolution using added parser

Examples of unparsed inputs:
- 20 seconds
- 30 days, 40 minutes, and 50 seconds
- 10h20m30s
- 3.5 days 30 seconds
- 1234.123     milliseconds