### PR TITLE
Add instigator to zombie events damaging & dying

### DIFF
--- a/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDamagingEvent.cs
@@ -15,22 +15,17 @@ namespace OpenMod.Unturned.Zombies.Events
 
         public ERagdollEffect RagdollEffect { get; set; }
 
-        public bool TrackKill { get; set; }
-
-        public bool DropLoot { get; set; }
-
         public EZombieStunOverride StunOverride { get; set; }
 
         public bool IsCancelled { get; set; }
 
-        public UnturnedZombieDamagingEvent(UnturnedZombie zombie, UnturnedPlayer user, ushort damageAmount, Vector3 ragdoll, ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride) : base(zombie)
+        public UnturnedZombieDamagingEvent(UnturnedZombie zombie, UnturnedPlayer user, ushort damageAmount,
+            Vector3 ragdoll, ERagdollEffect ragdollEffect, EZombieStunOverride stunOverride) : base(zombie)
         {
             DamageAmount = damageAmount;
             Instigator = user;
             Ragdoll = ragdoll;
             RagdollEffect = ragdollEffect;
-            TrackKill = trackKill;
-            DropLoot = dropLoot;
             StunOverride = stunOverride;
         }
     }

--- a/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDamagingEvent.cs
@@ -1,4 +1,5 @@
 ﻿using OpenMod.API.Eventing;
+using OpenMod.Unturned.Players;
 using SDG.Unturned;
 using UnityEngine;
 
@@ -10,6 +11,8 @@ namespace OpenMod.Unturned.Zombies.Events
 
         public Vector3 Ragdoll { get; set; }
 
+        public UnturnedPlayer Instigator { get; set; }
+
         public ERagdollEffect RagdollEffect { get; set; }
 
         public bool TrackKill { get; set; }
@@ -20,9 +23,10 @@ namespace OpenMod.Unturned.Zombies.Events
 
         public bool IsCancelled { get; set; }
 
-        public UnturnedZombieDamagingEvent(UnturnedZombie zombie, ushort damageAmount, Vector3 ragdoll, ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride) : base(zombie)
+        public UnturnedZombieDamagingEvent(UnturnedZombie zombie, UnturnedPlayer user, ushort damageAmount, Vector3 ragdoll, ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride) : base(zombie)
         {
             DamageAmount = damageAmount;
+            Instigator = user;
             Ragdoll = ragdoll;
             RagdollEffect = ragdollEffect;
             TrackKill = trackKill;

--- a/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDyingEvent.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDyingEvent.cs
@@ -1,11 +1,14 @@
-﻿using SDG.Unturned;
+﻿using OpenMod.Unturned.Players;
+using SDG.Unturned;
 using UnityEngine;
 
 namespace OpenMod.Unturned.Zombies.Events
 {
     public class UnturnedZombieDyingEvent : UnturnedZombieDamagingEvent
     {
-        public UnturnedZombieDyingEvent(UnturnedZombie zombie, ushort damageAmount, Vector3 ragdoll, ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride) : base(zombie, damageAmount, ragdoll, ragdollEffect, trackKill, dropLoot, stunOverride)
+        public UnturnedZombieDyingEvent(UnturnedZombie zombie, UnturnedPlayer player, ushort damageAmount, Vector3 ragdoll,
+            ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride)
+                : base(zombie, player, damageAmount, ragdoll, ragdollEffect, trackKill, dropLoot, stunOverride)
         {
 
         }

--- a/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDyingEvent.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/UnturnedZombieDyingEvent.cs
@@ -6,11 +6,10 @@ namespace OpenMod.Unturned.Zombies.Events
 {
     public class UnturnedZombieDyingEvent : UnturnedZombieDamagingEvent
     {
-        public UnturnedZombieDyingEvent(UnturnedZombie zombie, UnturnedPlayer player, ushort damageAmount, Vector3 ragdoll,
-            ERagdollEffect ragdollEffect, bool trackKill, bool dropLoot, EZombieStunOverride stunOverride)
-                : base(zombie, player, damageAmount, ragdoll, ragdollEffect, trackKill, dropLoot, stunOverride)
+        public UnturnedZombieDyingEvent(UnturnedZombie zombie, UnturnedPlayer player, ushort damageAmount,
+            Vector3 ragdoll, ERagdollEffect ragdollEffect, EZombieStunOverride stunOverride)
+                : base(zombie, player, damageAmount, ragdoll, ragdollEffect, stunOverride)
         {
-
         }
     }
 }

--- a/unturned/OpenMod.Unturned/Zombies/Events/ZombieEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/ZombieEventsListener.cs
@@ -91,7 +91,7 @@ namespace OpenMod.Unturned.Zombies.Events
             parameters.damage = @event.DamageAmount;
             parameters.direction = @event.Ragdoll;
             parameters.ragdollEffect = @event.RagdollEffect;
-            parameters.instigator = player.Player;
+            parameters.instigator = @event.Instigator.Player;
             // parameters.trackKill = @event.TrackKill;
             // parameters.dropLoot = @event.DropLoot;
             parameters.zombieStunOverride = @event.StunOverride;

--- a/unturned/OpenMod.Unturned/Zombies/Events/ZombieEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Zombies/Events/ZombieEventsListener.cs
@@ -77,13 +77,13 @@ namespace OpenMod.Unturned.Zombies.Events
 
             if (damageAmount >= zombie.Health)
             {
-                @event = new UnturnedZombieDyingEvent(zombie, player, damageAmount, parameters.direction, parameters.ragdollEffect, true, true,
-                    parameters.zombieStunOverride);
+                @event = new UnturnedZombieDyingEvent(zombie, player, damageAmount, parameters.direction,
+                    parameters.ragdollEffect, parameters.zombieStunOverride);
             }
             else
             {
-                @event = new UnturnedZombieDamagingEvent(zombie, player, damageAmount, parameters.direction, parameters.ragdollEffect, true,
-                    true, parameters.zombieStunOverride);
+                @event = new UnturnedZombieDamagingEvent(zombie, player, damageAmount, parameters.direction,
+                    parameters.ragdollEffect, parameters.zombieStunOverride);
             }
 
             Emit(@event);
@@ -92,8 +92,6 @@ namespace OpenMod.Unturned.Zombies.Events
             parameters.direction = @event.Ragdoll;
             parameters.ragdollEffect = @event.RagdollEffect;
             parameters.instigator = @event.Instigator.Player;
-            // parameters.trackKill = @event.TrackKill;
-            // parameters.dropLoot = @event.DropLoot;
             parameters.zombieStunOverride = @event.StunOverride;
             shouldAllow = !@event.IsCancelled;
         }


### PR DESCRIPTION
Should remove `DropLoot` & `TrackKill` from the event because it will be always true? Fixes #253 