### PR TITLE
Fixes runtime error from incorrect hot reloading config parsing

### DIFF
--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -153,7 +153,26 @@ namespace OpenMod.Runtime
                         .Build();
 
                     var config = deserializer.Deserialize<Dictionary<string, object>>(yaml);
-                    Hotloader.Enabled = (bool?)config["hotreloading"] ?? true;
+
+                    var hotReloadingEnabled = true;
+
+                    if (config.TryGetValue("hotreloading", out var unparsed))
+                    {
+                        switch (unparsed)
+                        {
+                            case bool value:
+                                hotReloadingEnabled = value;
+                                break;
+                            case string strValue when bool.TryParse(strValue, out var parsed):
+                                hotReloadingEnabled = parsed;
+                                break;
+                            default:
+                                m_Logger.LogWarning("Unknown config for 'hotreloading' in OpenMod configuration: " + unparsed);
+                                break;
+                        }
+                    }
+
+                    Hotloader.Enabled = hotReloadingEnabled;
                 }
 
                 await startup.LoadPluginAssembliesAsync();


### PR DESCRIPTION
Error that occurs:
```
System.InvalidCastException: Specified cast is not valid.
  at System.Nullable`1[T].Unbox (System.Object o) [0x0000d] in <9577ac7a62ef43179789031239ba8798>:0
  at OpenMod.Runtime.Runtime+<InitAsync>d__48.MoveNext () [0x004c0] in <bbfef474430f441c83fd7dfee08b80ff>:0
Failed to initialize nexus!
Specified cast is not valid.
  at System.Nullable`1[T].Unbox (System.Object o) [0x0000d] in <9577ac7a62ef43179789031239ba8798>:0
  at OpenMod.Runtime.Runtime+<InitAsync>d__48.MoveNext () [0x00889] in <bbfef474430f441c83fd7dfee08b80ff>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0
  at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException[TResult] (System.Threading.Tasks.Task`1[TResult] task) [0x00015] in <a98182632eb245adb24e66ecaa8eeab5>:0
  at Nito.AsyncEx.AsyncContext+<>c__DisplayClass16_0`1[TResult].<Run>b__0 (System.Threading.Tasks.Task`1[TResult] t) [0x0000b] in <ae3f77a0cc84476faeb835e8b2bfa4c2>:0
  at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2[TAntecedentResult,TResult].InnerInvoke () [0x00024] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Threading.Tasks.Task.Execute () [0x00010] in <9577ac7a62ef43179789031239ba8798>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0
  at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException[TResult] (System.Threading.Tasks.Task`1[TResult] task) [0x00015] in <a98182632eb245adb24e66ecaa8eeab5>:0
  at Nito.AsyncEx.AsyncContext.Run[TResult] (System.Func`1[TResult] action) [0x0006c] in <ae3f77a0cc84476faeb835e8b2bfa4c2>:0
  at OpenMod.Core.Helpers.AsyncHelper.RunSync[TResult] (System.Func`1[TResult] func) [0x00001] in <ae0a82a87bcb4e37bc4ed1391ac868c8>:0
  at OpenMod.Runtime.Runtime.Init (System.Collections.Generic.List`1[T] openModAssemblies, OpenMod.API.RuntimeInitParameters parameters, System.Func`1[TResult] hostBuilderFunc) [0x00023] in <bbfef474430f441c83fd7dfee08b80ff>:0
  at OpenMod.Unturned.Module.Dev.OpenModUnturnedModule.OnInitialize () [0x000a3] in <6e2dc10ab5a241a0bb266dbe2b05106d>:0
  at OpenMod.Unturned.Module.Dev.OpenModUnturnedModule.initialize () [0x0002d] in <6e2dc10ab5a241a0bb266dbe2b05106d>:0
  at SDG.Framework.Modules.Module.initialize () [0x00063] in <edb79d7f2f23429f92bfc411e5532edf>:0
```