### PR TITLE
Fixes permissions not reregistering after reload

### DIFF
--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -82,6 +82,8 @@ namespace OpenMod.Runtime
         {
             try
             {
+                IsDisposing = false;
+
                 var openModCoreAssembly = typeof(AsyncHelper).Assembly;
                 if (!openModHostAssemblies.Contains(openModCoreAssembly))
                 {


### PR DESCRIPTION
Likely fixes other unknown problems as well which reference Runtime.IsDisposing