### PR TITLE
Fix PluginService cannot be disposed async

### DIFF
--- a/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
+++ b/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
@@ -114,7 +114,6 @@ namespace OpenMod.Core.Plugins
             }
 
             await EventBus.EmitAsync(this, this, new PluginDisposedEvent(this));
-            LifetimeScope?.Dispose();
         }
 
         protected virtual ValueTask<bool> OnDispose()


### PR DESCRIPTION
Fixes #226
Also, dispose lifetimeScope when plugin it's crashed. Fixes #296 

edit: After testing i notice that event don't called
https://github.com/openmod/openmod/blob/2006282cfe032a8fbf0c8562a13fccb6d04902ff/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs#L116