### PR TITLE
Fix Microsoft.Bcl.AsyncInterfaces not found

### DIFF
--- a/framework/OpenMod.API/OpenMod.API.csproj
+++ b/framework/OpenMod.API/OpenMod.API.csproj
@@ -16,4 +16,10 @@
     <PackageReference Include="Semver" Version="2.0.6" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!-- Provides the IAsyncEnumerable<T> and IAsyncDisposable interfaces and helper types for .NET Standard 2.0. -->
+    <!-- This package is not required starting with .NET Standard 2.1 and .NET Core 3.0. -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
While on net461 works fine, on netcoreapp3.1 throws
```
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
File name: 'Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'
   at OpenMod.Core.Ioc.LifetimeScopeExtensions.BeginLifetimeScopeEx(ILifetimeScope this, Action`1 configurationAction)
   at OpenMod.Runtime.Runtime.InitAsync(List`1 openModHostAssemblies, RuntimeInitParameters parameters, Func`1 hostBuilderFunc) in G:\csharp\openmod\openmod\framework\OpenMod.Runtime\Runtime.cs:line 210
   at OpenMod.Standalone.Program.Main(String[] args) in G:\csharp\openmod\openmod\standalone\OpenMod.Standalone\Program.cs:line 20
   at OpenMod.Standalone.Program.<Main>(String[] args)

```