### PR TITLE
Dispose console thread on shutdown

### DIFF
--- a/unturned/OpenMod.Unturned/Logging/OpenModConsoleInputOutput.cs
+++ b/unturned/OpenMod.Unturned/Logging/OpenModConsoleInputOutput.cs
@@ -48,7 +48,7 @@ namespace OpenMod.Unturned.Logging
             System.Console.InputEncoding = encoding;
 
             m_PreviousConsoleIn = System.Console.In;
-            
+
             var enableHistory = m_Configuration.GetSection("console:history").Get<bool>();
             var enableAutoComplete = m_Configuration.GetSection("console:autocomplete").Get<bool>();
 
@@ -81,6 +81,11 @@ namespace OpenMod.Unturned.Logging
             ReadLine.AutoCompletionHandler = null;
             ReadLine.HistoryEnabled = false;
             System.Console.SetIn(m_PreviousConsoleIn);
+
+            if (m_InputThread.IsAlive)
+            {
+                m_InputThread.Abort();
+            }
         }
 
         public void update()


### PR DESCRIPTION
Fixes `IOException: Invalid handle to path` error after running `/openmod restart` on Linux.

```
IOException: Invalid handle to path "/mnt/d/steamcmd_linux/steamapps/common/u3ds/[Unknown]"
  at System.IO.FileStream.ReadData (System.Runtime.InteropServices.SafeHandle safeHandle, System.Byte[] buf, System.Int32 offset, System.Int32 count) [0x0002d] in <9577ac7a62ef43179789031239ba8798>:0
  at System.IO.FileStream.ReadInternal (System.Byte[] dest, System.Int32 offset, System.Int32 count) [0x00026] in <9577ac7a62ef43179789031239ba8798>:0
  at System.IO.FileStream.Read (System.Byte[] array, System.Int32 offset, System.Int32 count) [0x000a1] in <9577ac7a62ef43179789031239ba8798>:0
  at System.IO.StreamReader.ReadBuffer () [0x000b3] in <9577ac7a62ef43179789031239ba8798>:0
  at System.IO.StreamReader.Read () [0x00021] in <9577ac7a62ef43179789031239ba8798>:0
  at System.TermInfoDriver.GetCursorPosition () [0x00048] in <9577ac7a62ef43179789031239ba8798>:0
  at System.TermInfoDriver.ReadUntilConditionInternal (System.Boolean haltOnNewLine) [0x0000e] in <9577ac7a62ef43179789031239ba8798>:0
  at System.TermInfoDriver.ReadLine () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0
  at System.ConsoleDriver.ReadLine () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Console.ReadLine () [0x00013] in <9577ac7a62ef43179789031239ba8798>:0
  at OpenMod.Unturned.Logging.OpenModConsoleInputOutput.OnInputThreadStart () [0x00016] in <e26690e908e54105944bd8d24928a542>:0
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in <9577ac7a62ef43179789031239ba8798>:0
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in <9577ac7a62ef43179789031239ba8798>:0
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
UnityEngine.<>c:<RegisterUECatcher>b__0_0(Object, UnhandledExceptionEventArgs)

(Filename: <9577ac7a62ef43179789031239ba8798> Line: 0)
```