### PR TITLE
Optimize buildable grouping in GetBuildablesAsync

### DIFF
--- a/unturned/OpenMod.Unturned/Building/UnturnedBuildableDirectory.cs
+++ b/unturned/OpenMod.Unturned/Building/UnturnedBuildableDirectory.cs
@@ -40,10 +40,10 @@ namespace OpenMod.Unturned.Building
                 var structureRegions = StructureManager.regions.Cast<StructureRegion>()
                     .ToList();
 
-                var barricadeDatas = barricadeRegions.SelectMany(brd => brd.barricades);
-                var barricadeDrops = barricadeRegions.SelectMany(brd => brd.drops);
-                var structureDatas = structureRegions.SelectMany(str => str.structures);
-                var structureDrops = structureRegions.SelectMany(str => str.drops);
+                var barricadeDatas = barricadeRegions.SelectMany(brd => brd.barricades).ToList();
+                var barricadeDrops = barricadeRegions.SelectMany(brd => brd.drops).ToList();
+                var structureDatas = structureRegions.SelectMany(str => str.structures).ToList();
+                var structureDrops = structureRegions.SelectMany(str => str.drops).ToList();
 
                 return barricadeDatas
                     .Select((k, i) =>


### PR DESCRIPTION
On BaseClustering, with an almost identical code, I tested getting all buildables and was seeing a time of ~40s for 45k buildables to be returned:
![image](https://media.discordapp.net/attachments/636284605166649344/803857547647516682/unknown.png)

After adding these 4 .ToList() and nothing else, time dropped down to 15ms for 45k buildables to be returned:
![image](https://media.discordapp.net/attachments/636284605166649344/803892091255521280/unknown.png)

Final code in BaseClustering:
![image](https://user-images.githubusercontent.com/17557714/105960913-26eacd00-607e-11eb-9c87-12d36022a131.png)


## **Final notes or more numbers**
The BaseClustering I tested was RM, BUT the code used in base clustering's GetBuildables is a near identical copy of this code, and uppon running multiple stopwatch runs on the code, I realized that selecting all of the structures (and barricades) was taking too long.
![image](https://user-images.githubusercontent.com/17557714/105960674-db382380-607d-11eb-8a0d-afaec0379ffb.png)
After simply adding 2 ToLists() to structureData's assignment and structureDrop's, the time to select the structures enumerable (and subsequently the barricades enumerable) dropped to just ms
![image](https://user-images.githubusercontent.com/17557714/105960714-e4c18b80-607d-11eb-806b-e35f4a0df475.png)
This should significantly speed up the method GetBuildablesAsync so it doesn't take an exorbitant amount of time when dealing with high counts of buildables.