### PR TITLE
Fix logging.yaml cannot be parsed

### DIFF
--- a/framework/OpenMod.Core/logging.yaml
+++ b/framework/OpenMod.Core/logging.yaml
@@ -1,6 +1,6 @@
 ﻿# Configuration for Serilog
-# This is the yaml equivalent of this: https://github.com/serilog/serilog-settings-configuration
-# For more, see https://openmod.github.io/openmod-docs/userdoc/concepts/logging.html
+# This is the yaml equivalent of this https://github.com/serilog/serilog-settings-configuration
+# For more see https://openmod.github.io/openmod-docs/userdoc/concepts/logging
 Serilog:
   Using:
   - Serilog


### PR DESCRIPTION
It's a very-very strange bug. Fixes #369 