### PR TITLE
Add functionality for packages.yaml within plugins to force install of packages

### DIFF
--- a/framework/OpenMod.Core/Helpers/AssemblyHelper.cs
+++ b/framework/OpenMod.Core/Helpers/AssemblyHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Resources;
 using System.Text.RegularExpressions;
@@ -12,6 +13,11 @@ namespace OpenMod.Core.Helpers
     [OpenModInternal]
     public static class AssemblyHelper
     {
+        private static readonly string[] s_ExcludedResources = new[]
+        {
+            "packages.yaml"
+        };
+
         public static void CopyAssemblyResources(Assembly assembly, string baseDir, bool overwrite = false)
         {
             baseDir ??= string.Empty;
@@ -39,6 +45,11 @@ namespace OpenMod.Core.Helpers
 
                 var regex = new Regex(Regex.Escape(assemblyName.Name + "."));
                 var fileName = regex.Replace(resourceName, string.Empty, 1);
+
+                if (s_ExcludedResources.Contains(fileName))
+                {
+                    continue;
+                }
 
                 var parts = fileName.Split('.');
                 fileName = "";

--- a/framework/OpenMod.NuGet/NuGetPackageManager.cs
+++ b/framework/OpenMod.NuGet/NuGetPackageManager.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using NuGet.Common;
+﻿using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -16,6 +8,14 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Versioning;
 using OpenMod.Common.Hotloading;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenMod.NuGet
 {
@@ -808,14 +808,8 @@ namespace OpenMod.NuGet
             return s_VersionRegex.Replace(fullAssemblyName, string.Empty);
         }
 
-        public async Task<int> InstallMissingPackagesAsync(bool updateExisting = true)
+        public async Task InstallPackagesAsync(ICollection<PackageIdentity> packages, bool updateExisting = true)
         {
-            if (m_PackagesDataStore == null)
-            {
-                throw new Exception("InstallMissingPackagesAsync failed: packages.yaml is not enabled.");
-            }
-
-            var packages = await m_PackagesDataStore.GetPackagesAsync();
             foreach (var package in packages)
             {
                 if (await IsPackageInstalledAsync(package.Id))
@@ -835,6 +829,18 @@ namespace OpenMod.NuGet
                 Logger.LogInformation($"Installing package: {package.Id}@{package.Version?.OriginalVersion ?? "latest"}");
                 await InstallAsync(package, allowPrereleaseVersions: true);
             }
+        }
+
+        public async Task<int> InstallMissingPackagesAsync(bool updateExisting = true)
+        {
+            if (m_PackagesDataStore == null)
+            {
+                throw new Exception("InstallMissingPackagesAsync failed: packages.yaml is not enabled.");
+            }
+
+            var packages = await m_PackagesDataStore.GetPackagesAsync();
+
+            await InstallPackagesAsync(packages);
 
             return packages.Count;
         }


### PR DESCRIPTION
Embedded resource `packages.yaml` must have same format as packages.yaml generated by OpenMod.
Example:
```
packages:
- id: SilK.Shops
  version: 1.0.0
``` 