### PR TITLE
YamlDataStore: Fix "File being used by another process"

### DIFF
--- a/framework/OpenMod.Core/Helpers/Retry.cs
+++ b/framework/OpenMod.Core/Helpers/Retry.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OpenMod.Core.Helpers
+{
+    internal static class Retry
+    {
+        public static async Task<T> DoAsync<T>(Func<T> action, TimeSpan retryInterval, int maxAttempts)
+        {
+            var exceptions = new List<Exception>();
+
+            for (var attempted = 0; attempted < maxAttempts; attempted++)
+            {
+                try
+                {
+                    if (attempted > 0)
+                    {
+                        await Task.Delay(retryInterval);
+                    }
+
+                    return action();
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            throw new AggregateException(exceptions);
+        }
+    }
+}


### PR DESCRIPTION
To reproduce:
1. Run OpenMod.Standalone
2. Edit `openmod.commands.yaml` - nothing will happen
3. Edit `openmod.commands.yaml` again - the exception will be thrown

```
[19:48:39 ERR][OpenMod.Core.Persistence.YamlDataStore] Error occured on file change for: G:\csharp\openmod\openmod\standalone\OpenMod.Standalone\bin\Debug\net461\openmod\openmod.commands.yaml
System.IO.IOException: The process cannot access the file 'G:\csharp\openmod\openmod\standalone\OpenMod.Standalone\bin\Debug\net461\openmod\openmod.commands.yaml' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolea
n checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.File.InternalReadAllBytes(String path, Boolean checkHost)
   at OpenMod.Core.Persistence.YamlDataStore.LoadAsync[T](String key)
   at OpenMod.Core.Commands.CommandDataStore.<LoadCommandsFromDisk>d__13.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at OpenMod.Core.Commands.CommandDataStore.<<GetRegisteredCommandsAsync>b__12_1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException[TResult](Task`1 task)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Nito.AsyncEx.Synchronous.TaskExtensions.WaitAndUnwrapException[TResult](Task`1 task)
   at Nito.AsyncEx.AsyncContext.Run[TResult](Func`1 action)
   at OpenMod.Core.Helpers.AsyncHelper.RunSync[TResult](Func`1 func)
   at OpenMod.Core.Commands.CommandDataStore.<GetRegisteredCommandsAsync>b__12_0()
   at OpenMod.Core.Persistence.YamlDataStore.OnFileChange(String key)
   at OpenMod.Core.Persistence.YamlDataStore.<EnsureFileSystemWatcherCreated>b__16_0(Object _, FileSystemEventArgs a)
```