### PR TITLE
Logging fixes and conformity to Serilog recommendations

### DIFF
--- a/framework/OpenMod.Core/Commands/CommandDataStore.cs
+++ b/framework/OpenMod.Core/Commands/CommandDataStore.cs
@@ -122,7 +122,7 @@ namespace OpenMod.Core.Commands
             m_Cache = await LoadCommandsFromDisk();
             m_ChangeWatcher = m_DataStore.AddChangeWatcher(CommandsKey, m_Runtime, () =>
             {
-                m_Logger.LogInformation("Commands have been reloaded.");
+                m_Logger.LogInformation("Commands have been reloaded");
                 m_Cache = AsyncHelper.RunSync(async () =>
                 {
                     var result = await LoadCommandsFromDisk();

--- a/framework/OpenMod.Core/Commands/CommandExecutor.cs
+++ b/framework/OpenMod.Core/Commands/CommandExecutor.cs
@@ -52,12 +52,13 @@ namespace OpenMod.Core.Commands
                 throw new Exception("Cannot execute command with null or empty args.");
             }
 
-            m_Logger.LogInformation($"Actor {actor.Type}/{actor.FullActorName} has executed command \"{string.Join(" ", args)}\".");
+            m_Logger.LogInformation("Actor {ActorType}/{ActorName} has executed command \"{Command}\"",
+                actor.Type, actor.FullActorName, string.Join(" ", args));
 
             var currentCommandAccessor = m_LifetimeScope.Resolve<ICurrentCommandContextAccessor>();
             var commandContextBuilder = m_LifetimeScope.Resolve<ICommandContextBuilder>();
             var stringLocalizer = m_LifetimeScope.Resolve<IOpenModStringLocalizer>();
-            
+
             var commandsRegistrations = await m_CommandStore.GetCommandsAsync();
             var commandContext = commandContextBuilder.CreateContext(actor, args, prefix, commandsRegistrations);
             var commandExecutingEvent = new CommandExecutingEvent(actor, commandContext);
@@ -89,7 +90,8 @@ namespace OpenMod.Core.Commands
                 sw.Start();
                 var command = commandContext.CommandRegistration!.Instantiate(commandContext.ServiceProvider);
                 await command.ExecuteAsync();
-                m_Logger.LogDebug($"Command \"{string.Join(" ", args)}\" executed in {sw.ElapsedMilliseconds}ms");
+                m_Logger.LogDebug("Command \"{Command}\" executed in {Ms}ms",
+                    string.Join(" ", args), sw.ElapsedMilliseconds);
 
                 currentCommandAccessor.Context = null;
             }
@@ -115,7 +117,9 @@ namespace OpenMod.Core.Commands
                     else
                     {
                         await actor.PrintMessageAsync("An internal error occured during the command execution.", Color.DarkRed);
-                        m_Logger.LogError(commandContext.Exception, $"Exception occured on command \"{string.Join(" ", args)}\" by actor {actor.Type}/{actor.DisplayName} ({actor.Id})");
+                        m_Logger.LogError(commandContext.Exception,
+                            "Exception occured on command \"{Command}\" by actor {ActorType}/{ActorName} ({ActorId})",
+                            string.Join(" ", args), actor.Type, actor.DisplayName, actor.Id);
                     }
                 }
 

--- a/framework/OpenMod.Core/Commands/CommandStore.cs
+++ b/framework/OpenMod.Core/Commands/CommandStore.cs
@@ -73,7 +73,7 @@ namespace OpenMod.Core.Commands
 
             if (m_CommandSources.Count == 0)
             {
-                m_Logger.LogDebug("InvalidateAsync: failed because no command sources were found; this is normal on booting.");
+                m_Logger.LogDebug("InvalidateAsync: failed because no command sources were found; this is normal on booting");
                 return;
             }
 
@@ -125,7 +125,7 @@ namespace OpenMod.Core.Commands
             }
 
             await m_CommandDataStore.SetRegisteredCommandsAsync(commandsData);
-            m_Logger.LogDebug($"Reloaded {commands.Count} commands.");
+            m_Logger.LogDebug("Reloaded {Count} commands", commands.Count);
         }
 
         public async Task<IReadOnlyCollection<ICommandRegistration>> GetCommandsAsync()

--- a/framework/OpenMod.Core/Commands/OpenModCommands/CommandRestart.cs
+++ b/framework/OpenMod.Core/Commands/OpenModCommands/CommandRestart.cs
@@ -57,7 +57,8 @@ namespace OpenMod.Core.Commands.OpenModCommands
                 }
             }
 
-            m_Logger.LogInformation($"Executing command after shutdown: {Environment.NewLine}{binaryPath} {arguments}");
+            m_Logger.LogInformation("Executing command after shutdown: {NewLine}{BinaryPath} {Arguments}",
+                Environment.NewLine, binaryPath, arguments);
 
             var startInfo = new ProcessStartInfo(binaryPath, arguments)
             {

--- a/framework/OpenMod.Core/Commands/OpenModComponentCommandSource.cs
+++ b/framework/OpenMod.Core/Commands/OpenModComponentCommandSource.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -19,8 +18,8 @@ namespace OpenMod.Core.Commands
         private readonly List<ICommandRegistration> m_Commands;
 
         public OpenModComponentCommandSource(
-            ILogger logger, 
-            IOpenModComponent openModComponent, 
+            ILogger logger,
+            IOpenModComponent openModComponent,
             Assembly assembly)
         {
             m_Logger = logger;
@@ -42,7 +41,9 @@ namespace OpenMod.Core.Commands
                 var commandAttribute = type.GetCustomAttribute<CommandAttribute>();
                 if (commandAttribute == null)
                 {
-                    m_Logger.LogWarning($"Type {type} is missing the [Command(string name)] attribute. Command will not be registered.");
+                    m_Logger.LogWarning(
+                        "Type {Type} is missing the [Command(string name)] attribute. Command will not be registered",
+                        type);
                     continue;
                 }
 
@@ -74,7 +75,7 @@ namespace OpenMod.Core.Commands
             }
             catch(Exception ex)
             {
-                m_Logger.LogDebug(ex, $"Exception in ScanTypeForCommands for type: {type}");
+                m_Logger.LogDebug(ex, "Exception in ScanTypeForCommands for type: {Type}", type);
             }
         }
 

--- a/framework/OpenMod.Core/Console/ConsoleActor.cs
+++ b/framework/OpenMod.Core/Console/ConsoleActor.cs
@@ -30,6 +30,7 @@ namespace OpenMod.Core.Console
 
         public Task PrintMessageAsync(string message, Color color)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_Logger.LogInformation(message);
             return Task.CompletedTask;
         }

--- a/framework/OpenMod.Core/Eventing/EventBus.cs
+++ b/framework/OpenMod.Core/Eventing/EventBus.cs
@@ -59,13 +59,14 @@ namespace OpenMod.Core.Eventing
 
             if (!component.IsComponentAlive)
             {
-                m_Logger.LogDebug($"{component.OpenModComponentId} tried to subscribe a callback but the component is not alive.");
+                m_Logger.LogDebug("{ComponentId} tried to subscribe a callback but the component is not alive",
+                    component.OpenModComponentId);
                 return NullDisposable.Instance;
             }
 
             var attribute = GetEventListenerAttribute(callback.Method);
             var subscription = new EventSubscription(component, callback.Invoke, attribute, eventName, component.LifetimeScope.BeginLifetimeScopeEx());
-            
+
             m_EventSubscriptions.Add(subscription);
             return new DisposeAction(() =>
             {
@@ -87,7 +88,8 @@ namespace OpenMod.Core.Eventing
 
             if (!component.IsComponentAlive)
             {
-                m_Logger.LogDebug($"{component.OpenModComponentId} tried to subscribe a callback but the component is not alive.");
+                m_Logger.LogDebug("{ComponentId} tried to subscribe a callback but the component is not alive",
+                    component.OpenModComponentId);
                 return NullDisposable.Instance;
             }
 
@@ -118,7 +120,8 @@ namespace OpenMod.Core.Eventing
 
             if (!component.IsComponentAlive)
             {
-                m_Logger.LogDebug($"{component.OpenModComponentId} tried to subscribe a callback but the component is not alive.");
+                m_Logger.LogDebug("{ComponentId} tried to subscribe a callback but the component is not alive",
+                    component.OpenModComponentId);
                 return NullDisposable.Instance;
             }
 
@@ -149,11 +152,13 @@ namespace OpenMod.Core.Eventing
 
             if (!component.IsComponentAlive)
             {
-                m_Logger.LogDebug($"{component.OpenModComponentId} tried to subscribe \"{assembly.FullName}\" but the component is not alive.");
+                m_Logger.LogDebug("{ComponentId} tried to subscribe \"{AsemblyName}\" but the component is not alive",
+                    component.OpenModComponentId, assembly.FullName);
                 return NullDisposable.Instance;
             }
 
-            m_Logger.LogDebug($"Subscribing assembly \"{assembly.FullName}\" for {component.OpenModComponentId}.");
+            m_Logger.LogDebug("Subscribing assembly \"{AssemblyName}\" for {ComponentId}",
+                assembly.FullName, component.OpenModComponentId);
 
             List<(Type eventListenerType, MethodInfo method, EventListenerAttribute eventListenerAttribute, Type eventType)> eventListeners = new List<(Type, MethodInfo, EventListenerAttribute, Type)>();
             var scope = component.LifetimeScope.BeginLifetimeScopeEx((builder =>
@@ -268,7 +273,8 @@ namespace OpenMod.Core.Eventing
 
             if (!component.IsComponentAlive)
             {
-                m_Logger.LogDebug($"EmitAsync called by {component.OpenModComponentId} for {@event.GetType().Name} but the component is not alive.");
+                m_Logger.LogDebug("EmitAsync called by {ComponentId} for {EventType} but the component is not alive",
+                    component.OpenModComponentId, @event.GetType().Name);
                 return;
             }
 
@@ -287,7 +293,7 @@ namespace OpenMod.Core.Eventing
             {
                 string eventName = GetEventName(eventType);
 
-                m_Logger.LogTrace($"Emitting event: {eventName}");
+                m_Logger.LogTrace("Emitting event: {EventName}", eventName);
                 var eventSubscriptions
                     = m_EventSubscriptions
                         .Where(c => (c.EventType != null && c.EventType == eventType)
@@ -298,7 +304,7 @@ namespace OpenMod.Core.Eventing
 
                 if (eventSubscriptions.Count == 0)
                 {
-                    m_Logger.LogTrace($"No event subscriptions found for: {eventName}");
+                    m_Logger.LogTrace("No event subscriptions found for: {EventName}", eventName);
                     continue;
                 }
 
@@ -353,18 +359,19 @@ namespace OpenMod.Core.Eventing
                                 {
                                     cancellableEvent.IsCancelled = wasCancelled;
                                     m_Logger.LogWarning(
-                                        $"{((IOpenModComponent)@subscription.Owner.Target).OpenModComponentId} changed {@eventName} cancellation status with Monitor priority which is not permitted.");
+                                        "{ComponentId} changed {EventName} cancellation status with Monitor priority which is not permitted",
+                                        ((IOpenModComponent) @subscription.Owner.Target).OpenModComponentId, eventName);
                                 }
                             }
                         }
                         catch (Exception ex)
                         {
-                            m_Logger.LogError(ex, $"Exception occured during event {@eventName}");
+                            m_Logger.LogError(ex, "Exception occured during event {EventName}", eventName);
                         }
                     }
                 }
 
-                m_Logger.LogTrace($"{eventName}: Finished.");
+                m_Logger.LogTrace("{EventName}: Finished", eventName);
             }
 
             callback?.Invoke(@event);

--- a/framework/OpenMod.Core/Helpers/AssemblyHelper.cs
+++ b/framework/OpenMod.Core/Helpers/AssemblyHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Resources;
@@ -19,7 +18,7 @@ namespace OpenMod.Core.Helpers
             "packages.yaml"
         };
 
-        public static void CopyAssemblyResources(Assembly assembly, string baseDir, bool overwrite = false)
+        public static void CopyAssemblyResources(Assembly assembly, string? baseDir, bool overwrite = false)
         {
             baseDir ??= string.Empty;
 
@@ -41,7 +40,9 @@ namespace OpenMod.Core.Helpers
 
                 if (!resourceName.Contains(assemblyName.Name + "."))
                 {
-                    Log.Warning($"{resourceName} does not contain assembly name in assembly: {assemblyName.Name}. <AssemblyName> and <RootNamespace> must be equal inside your plugins .csproj file.");
+                    Log.Warning(
+                        "{ResourceName} does not contain assembly name in assembly: {AssemblyName}. <AssemblyName> and <RootNamespace> must be equal inside your plugins .csproj file",
+                        resourceName, assemblyName.Name);
                 }
 
                 var regex = new Regex(Regex.Escape(assemblyName.Name + "."));
@@ -93,12 +94,12 @@ namespace OpenMod.Core.Helpers
                 using var stream = assembly.GetManifestResourceStream(resourceName);
                 using var reader = new StreamReader(stream ?? throw new MissingManifestResourceException($"Couldn't find resource: {resourceName}"));
                 var fileContent = reader.ReadToEnd();
-                
+
                 if (File.Exists(filePath) && !overwrite)
                 {
                     continue;
                 }
-                
+
                 File.WriteAllText(filePath, fileContent);
             }
         }

--- a/framework/OpenMod.Core/Helpers/AsyncHelper.cs
+++ b/framework/OpenMod.Core/Helpers/AsyncHelper.cs
@@ -84,7 +84,7 @@ namespace OpenMod.Core.Helpers
                     }
                     else
                     {
-                        Log.Error(e, $"Exception occured in task \"{name}\"");
+                        Log.Error(e, "Exception occured in task \"{TaskName}\"", name);
                     }
                 }
             });

--- a/framework/OpenMod.Core/Ioc/Extensions/ContainerBuilderExtensions.cs
+++ b/framework/OpenMod.Core/Ioc/Extensions/ContainerBuilderExtensions.cs
@@ -31,9 +31,9 @@ namespace OpenMod.Core.Ioc.Extensions
             return registrationBuilder;
         }
 
-        public static ContainerBuilder PopulateServices(this ContainerBuilder containerBuilder, 
-            ServiceCollection serviceCollection, 
-            Func<ServiceDescriptor, bool>? serviceFilter = null, 
+        public static ContainerBuilder PopulateServices(this ContainerBuilder containerBuilder,
+            ServiceCollection serviceCollection,
+            Func<ServiceDescriptor, bool>? serviceFilter = null,
             bool replaceServices = false,
             bool autowire = true)
         {
@@ -52,7 +52,8 @@ namespace OpenMod.Core.Ioc.Extensions
 
                 if (descriptor.ImplementationType != null)
                 {
-                    Log.Information($"Descriptor: impl {descriptor.ServiceType}, {descriptor.ImplementationType}");
+                    Log.Information("Descriptor: impl {ServiceType}, {ImplementationType}",
+                        descriptor.ServiceType, descriptor.ImplementationType);
 
                     // Test if the an open generic type is being registered
                     var serviceTypeInfo = descriptor.ServiceType.GetTypeInfo();
@@ -105,7 +106,8 @@ namespace OpenMod.Core.Ioc.Extensions
                 }
                 else
                 {
-                    Log.Information($"Descriptor: instance {descriptor.ServiceType}, {descriptor.ImplementationInstance.GetType()}");
+                    Log.Information("Descriptor: instance {ServiceType}, {ImplementationType}",
+                        descriptor.ServiceType, descriptor.ImplementationInstance.GetType());
                     var registrator = containerBuilder
                         .RegisterInstance(descriptor.ImplementationInstance)
                         .As(descriptor.ServiceType)

--- a/framework/OpenMod.Core/Ioc/ServiceRegistrationHelper.cs
+++ b/framework/OpenMod.Core/Ioc/ServiceRegistrationHelper.cs
@@ -23,7 +23,7 @@ namespace OpenMod.Core.Ioc
             }
             catch (ReflectionTypeLoadException ex) //this ignores missing optional dependencies
             {
-                logger?.LogTrace(ex, $"Some optional dependencies are missing for \"{assembly}\"");
+                logger?.LogTrace(ex, "Some optional dependencies are missing for \"{Assembly}\"", assembly);
                 if (ex.LoaderExceptions != null && ex.LoaderExceptions.Length > 0)
                 {
                     foreach (var loaderException in ex.LoaderExceptions)
@@ -57,14 +57,17 @@ namespace OpenMod.Core.Ioc
                     if (interfaces.Length == 0)
                     {
                         logger?.LogWarning(
-                            $"Type {type.FullName} in assembly {assembly.FullName} has been marked as ServiceImplementation but does not inherit any services!\nDid you forget to add [Service] to your interfaces?");
+                            "Type {TypeName} in assembly {AssemblyName} has been marked as ServiceImplementation but does not inherit any services!\nDid you forget to add [Service] to your interfaces?",
+                            type.FullName, assembly.FullName);
                         continue;
                     }
 
                 }
                 catch (Exception ex)
                 {
-                    logger?.LogWarning($"FindFromAssembly has failed for type: {type.FullName} while searching for {typeof(T).FullName}", ex);
+                    logger?.LogWarning(ex,
+                        "FindFromAssembly has failed for type: {TypeName} while searching for {SearchTypeName}",
+                        type.FullName, typeof(T).FullName);
                     continue;
                 }
 

--- a/framework/OpenMod.Core/Jobs/JobScheduler.cs
+++ b/framework/OpenMod.Core/Jobs/JobScheduler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Cronos;
@@ -215,19 +214,19 @@ namespace OpenMod.Core.Jobs
 
             if (string.IsNullOrEmpty(job.Name))
             {
-                m_Logger.LogError($"Job of type {job.Task} has no name set.");
+                m_Logger.LogError("Job of type {TaskType} has no name set", job.Task);
                 return;
             }
 
             if (string.IsNullOrEmpty(job.Task))
             {
-                m_Logger.LogError($"Job \"{job.Name}\" has no task set.");
+                m_Logger.LogError("Job \"{JobName}\" has no task set", job.Name);
                 return;
             }
 
             if (string.IsNullOrEmpty(job.Schedule))
             {
-                m_Logger.LogError($"Job \"{job.Name}\" has no schedule set.");
+                m_Logger.LogError("Job \"{JobName}\" has no schedule set", job.Name);
                 return;
             }
 
@@ -258,7 +257,8 @@ namespace OpenMod.Core.Jobs
                 return;
             }
 
-            m_Logger.LogInformation($"Scheduling job \"{job.Name}\" with schedule \"{job.Schedule}\"");
+            m_Logger.LogInformation("Scheduling job \"{JobName}\" with schedule \"{JobSchedule}\"",
+                job.Name, job.Schedule);
             ScheduleCronJob(job);
         }
 
@@ -278,7 +278,8 @@ namespace OpenMod.Core.Jobs
             }
             catch (Exception ex)
             {
-                m_Logger.LogError(ex, $"Invalid crontab syntax \"{job.Schedule}\" for job: {job.Name}");
+                m_Logger.LogError(ex, "Invalid crontab syntax \"{JobSchedule}\" for job: {JobName}",
+                    job.Schedule, job.Name);
                 return;
             }
 
@@ -320,11 +321,11 @@ namespace OpenMod.Core.Jobs
             var jobExecutor = m_JobExecutors.FirstOrDefault(d => d.SupportsType(job.Task!));
             if (jobExecutor == null)
             {
-                m_Logger.LogError($"[{job.Name}] Unknown job type: {job.Task}");
+                m_Logger.LogError("[{JobName}] Unknown job type: {TaskType}", job.Name, job.Task);
                 return;
             }
 
-            m_Logger.LogInformation($"Executing job \"{job.Name}\"...");
+            m_Logger.LogInformation("Executing job \"{JobName}\"...", job.Name);
 
             try
             {
@@ -332,7 +333,7 @@ namespace OpenMod.Core.Jobs
             }
             catch (Exception ex)
             {
-                m_Logger.LogError(ex, $"Job \"{job.Name}\" generated an exception.");
+                m_Logger.LogError(ex, "Job \"{JobName}\" generated an exception", job.Name);
             }
         }
 

--- a/framework/OpenMod.Core/Jobs/OpenModCommandTaskActor.cs
+++ b/framework/OpenMod.Core/Jobs/OpenModCommandTaskActor.cs
@@ -31,6 +31,7 @@ namespace OpenMod.Core.Jobs
 
         public Task PrintMessageAsync(string message)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_Logger.LogInformation(message);
             return Task.CompletedTask;
         }

--- a/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
+++ b/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
@@ -43,7 +43,7 @@ namespace OpenMod.Core.Jobs
                     continue;
                 }
 
-                m_Logger.LogInformation($"[{task.JobName}] Running OpenMod command: {command!}");
+                m_Logger.LogInformation("[{JobName}] Running OpenMod command: {Command}", task.JobName, command!);
 
                 var args = ArgumentsParser.ParseArguments(command!);
                 await m_CommandExecutor.ExecuteAsync(m_Actor, args, string.Empty);

--- a/framework/OpenMod.Core/Jobs/SystemCommandTaskExecutor.cs
+++ b/framework/OpenMod.Core/Jobs/SystemCommandTaskExecutor.cs
@@ -41,7 +41,7 @@ namespace OpenMod.Core.Jobs
                     continue;
                 }
 
-                m_Logger.LogInformation($"[{task.JobName}] Running system command: {command!}");
+                m_Logger.LogInformation("[{JobName}] Running system command: {Command}", task.JobName, command!);
                 var args = ArgumentsParser.ParseArguments(command!);
                 var startInfo = new ProcessStartInfo(args[0], command!.Replace(args[0] + " ", string.Empty))
                 {

--- a/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
+++ b/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
@@ -37,7 +37,7 @@ namespace OpenMod.Core.Localization
             var reloadToken = translations.GetReloadToken();
             reloadToken.RegisterChangeCallback(_ =>
             {
-                m_Logger.LogInformation($"Reloading translations: {Path.Combine(location, baseName + ".yaml")}");
+                m_Logger.LogInformation("Reloading translations: {Path}", Path.Combine(location, baseName + ".yaml"));
             }, null);
 
             return new ConfigurationBasedStringLocalizer(translations);

--- a/framework/OpenMod.Core/Permissions/DefaultPermissionCheckProvider.cs
+++ b/framework/OpenMod.Core/Permissions/DefaultPermissionCheckProvider.cs
@@ -41,23 +41,23 @@ namespace OpenMod.Core.Permissions
             }
 
 
-            m_Logger.LogDebug("Granted permissions for " + actor.DisplayName + ": ");
+            m_Logger.LogDebug("Granted permissions for {ActorName}: ", actor.DisplayName);
             foreach (var knownPerm in grantedPermissions)
             {
-                m_Logger.LogDebug("* " + knownPerm);
+                m_Logger.LogDebug("* {KnownPerm}", knownPerm);
             }
 
-            m_Logger.LogDebug("Denied permissions for " + actor.DisplayName + ": ");
+            m_Logger.LogDebug("Denied permissions for {ActorName}: ", actor.DisplayName);
             foreach (var knownPerm in deniedPermissions)
             {
-                m_Logger.LogDebug("* " + knownPerm);
+                m_Logger.LogDebug("* {KnownPerm}", knownPerm);
             }
 
 
             var permissionTree = BuildPermissionTree(permission);
             foreach (var permissionNode in permissionTree)
             {
-                m_Logger.LogDebug("Checking node: " + permissionNode);
+                m_Logger.LogDebug("Checking node: {PermissionNode}", permissionNode);
 
                 if (deniedPermissions.Any(c => CheckPermissionEquals(permissionNode, c)))
                 {
@@ -107,10 +107,10 @@ namespace OpenMod.Core.Permissions
             };
 
             var separatorIndices = permission.AllIndexesOf(":");
-            
+
             // replace all ":" with "." for more simple code
             // we will restore : later again
-            permission = permission.Replace(":", "."); 
+            permission = permission.Replace(":", ".");
 
             var parentPath = new StringBuilder();
             foreach (var childPath in permission.Split('.'))

--- a/framework/OpenMod.Core/Permissions/PermissionChecker.cs
+++ b/framework/OpenMod.Core/Permissions/PermissionChecker.cs
@@ -58,15 +58,17 @@ namespace OpenMod.Core.Permissions
             foreach (var provider in m_PermissionCheckProviders.Where(c => c.SupportsActor(actor)))
             {
                 var result = await provider.CheckPermissionAsync(actor, permission);
-                m_Logger.LogDebug($"{actor.FullActorName} permission check result for \"{permission}\" ({provider.GetType().Name}): {result}");
-             
+                m_Logger.LogDebug("{0} permission check result for \"{ActorName}\" ({Permission}): {Result}",
+                    actor.FullActorName, permission, provider.GetType().Name, result);
+
                 if (result != PermissionGrantResult.Default)
                 {
                     return result;
                 }
             }
 
-            m_Logger.LogDebug($"{actor.FullActorName} permission check \"{permission}\" returning default");
+            m_Logger.LogDebug("{ActorName} permission check \"{Permission}\" returning default",
+                actor.FullActorName, permission);
             return registration.DefaultGrant;
         }
 

--- a/framework/OpenMod.Core/Permissions/PermissionRolesDataStore.cs
+++ b/framework/OpenMod.Core/Permissions/PermissionRolesDataStore.cs
@@ -31,8 +31,8 @@ namespace OpenMod.Core.Permissions
 
         public PermissionRolesDataStore(
             ILogger<PermissionRolesDataStore> logger,
-            IOpenModDataStoreAccessor dataStoreAccessor, 
-            IRuntime runtime) 
+            IOpenModDataStoreAccessor dataStoreAccessor,
+            IRuntime runtime)
         {
             m_DataStore = dataStoreAccessor.DataStore;
             m_Logger = logger;
@@ -151,7 +151,7 @@ namespace OpenMod.Core.Permissions
 
         public virtual async Task ReloadAsync()
         {
-            m_Logger.LogInformation("Permissions have been reloaded.");
+            m_Logger.LogInformation("Permissions have been reloaded");
             m_CachedPermissionRolesData = await m_DataStore.LoadAsync<PermissionRolesData>(RolesKey) ?? new PermissionRolesData();
         }
 

--- a/framework/OpenMod.Core/Persistence/YamlDataStore.cs
+++ b/framework/OpenMod.Core/Persistence/YamlDataStore.cs
@@ -106,7 +106,7 @@ namespace OpenMod.Core.Persistence
                 AsyncHelper.Schedule(
                     name: GetType().Name + "_" + nameof(ChangeEventHandler),
                     task: () => ChangeEventHandler(args),
-                    ex => m_Logger?.LogError(ex, $"Error occured on file change for: {args.FullPath}"));
+                    ex => m_Logger?.LogError(ex, "Error occured on file change for: {FilePath}", args.FullPath));
             };
         }
 
@@ -144,7 +144,7 @@ namespace OpenMod.Core.Persistence
                 {
                     if (DecrementWriteCounter(key))
                     {
-                        m_Logger?.LogDebug($"File changed: {a.FullPath} ({a.ChangeType:X})");
+                        m_Logger?.LogDebug("File changed: {FilePath} ({ChangeType:X})", a.FullPath, a.ChangeType);
                         OnFileChange(key);
                     }
                 }
@@ -363,7 +363,8 @@ namespace OpenMod.Core.Persistence
 
                 AddChangeWatcher(key, m_Runtime!, () =>
                 {
-                    m_Logger.LogInformation($"Reloaded {m_Prefix ?? string.Empty}{key}{m_Suffix ?? string.Empty}.yaml.");
+                    m_Logger.LogInformation("Reloaded {Prefix}{Key}{Suffix}.yaml",
+                        m_Prefix ?? string.Empty, key, m_Suffix ?? string.Empty);
                 });
             }
         }

--- a/framework/OpenMod.Core/Plugins/FileSystemPluginAssembliesSource.cs
+++ b/framework/OpenMod.Core/Plugins/FileSystemPluginAssembliesSource.cs
@@ -49,7 +49,7 @@ namespace OpenMod.Core.Plugins
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogWarning(ex, $"Failed to load plugin metadata from file: {file}");
+                    m_Logger.LogWarning(ex, "Failed to load plugin metadata from file: {File}", file);
                 }
             }
 

--- a/framework/OpenMod.Core/Plugins/NuGet/OpenModNuGetLogger.cs
+++ b/framework/OpenMod.Core/Plugins/NuGet/OpenModNuGetLogger.cs
@@ -35,6 +35,7 @@ namespace OpenMod.Core.Plugins.NuGet
 
             switch (level)
             {
+                // ReSharper disable TemplateIsNotCompileTimeConstantProblem
                 case LogLevel.Debug:
                     m_Logger.LogDebug(text);
                     break;
@@ -53,6 +54,7 @@ namespace OpenMod.Core.Plugins.NuGet
                 case LogLevel.Error:
                     m_Logger.LogError(text);
                     break;
+                // ReSharper restore TemplateIsNotCompileTimeConstantProblem
                 default:
                     throw new ArgumentOutOfRangeException(nameof(level), level, null);
             }

--- a/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
+++ b/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
@@ -75,7 +75,7 @@ namespace OpenMod.Core.Plugins
         public virtual Task LoadAsync()
         {
             Logger = m_LoggerFactory.CreateLogger(GetType());
-            Logger.LogInformation($"[loading] {DisplayName} v{Version}");
+            Logger.LogInformation("[loading] {DisplayName} v{Version}", DisplayName, Version);
 
             m_CommandSource = new OpenModComponentCommandSource(Logger, this, GetType().Assembly);
             m_CommandStoreOptions.Value.AddCommandSource(m_CommandSource);

--- a/framework/OpenMod.Core/Plugins/PluginActivator.cs
+++ b/framework/OpenMod.Core/Plugins/PluginActivator.cs
@@ -85,7 +85,8 @@ namespace OpenMod.Core.Plugins
                 if (pluginMetadata == null)
                 {
                     m_Logger.LogError(
-                        $"Failed to load plugin from assembly {assembly}: couldn't find any plugin metadata");
+                        "Failed to load plugin from assembly {Assembly}: couldn't find any plugin metadata",
+                        assembly);
                     return null;
                 }
 
@@ -93,14 +94,16 @@ namespace OpenMod.Core.Plugins
                 if (pluginTypes.Count == 0)
                 {
                     m_Logger.LogError(
-                        $"Failed to load plugin from assembly {assembly}: couldn't find any IOpenModPlugin implementation");
+                        "Failed to load plugin from assembly {Assembly}: couldn't find any IOpenModPlugin implementation",
+                        assembly);
                     return null;
                 }
 
                 if (pluginTypes.Count > 1)
                 {
                     m_Logger.LogError(
-                        $"Failed to load plugin from assembly {assembly}: assembly has multiple IOpenModPlugin instances");
+                        "Failed to load plugin from assembly {Assembly}: assembly has multiple IOpenModPlugin instances",
+                        assembly);
                     return null;
                 }
 
@@ -217,8 +220,8 @@ namespace OpenMod.Core.Plugins
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex,
-                        $"Failed to load plugin from type: {pluginType.FullName} in assembly: {assembly.FullName}");
+                    m_Logger.LogError(ex, "Failed to load plugin from type: {PluginName} in assembly: {AssemblyName}",
+                        pluginType.FullName, assembly.FullName);
                     return null;
                 }
 
@@ -231,7 +234,8 @@ namespace OpenMod.Core.Plugins
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"Failed to load plugin: {pluginInstance.DisplayName} v{pluginInstance.Version}");
+                    m_Logger.LogError(ex, "Failed to load plugin: {PluginName} v{PluginVersion}",
+                        pluginInstance.DisplayName, pluginInstance.Version);
 
                     try
                     {
@@ -250,7 +254,7 @@ namespace OpenMod.Core.Plugins
             }
             catch (Exception ex)
             {
-                m_Logger.LogError(ex, $"Failed to load plugin from assembly: {assembly.FullName}");
+                m_Logger.LogError(ex, "Failed to load plugin from assembly: {AssemblyName}", assembly.FullName);
                 return null;
             }
         }
@@ -266,10 +270,11 @@ namespace OpenMod.Core.Plugins
                 {
                     return;
                 }
-                
+
                 AsyncHelper.Schedule($"Configuration changed event for {pluginInstance.OpenModComponentId}", () =>
                 {
-                    pluginLogger.LogInformation($"Configuration updated for plugin: {pluginInstance.OpenModComponentId}");
+                    pluginLogger.LogInformation("Configuration updated for plugin: {ComponentId}",
+                        pluginInstance.OpenModComponentId);
                     return m_EventBus.EmitAsync(m_Runtime, this, new PluginConfigurationChangedEvent(pluginInstance, pluginConfiguration));
                 });
 
@@ -300,12 +305,12 @@ namespace OpenMod.Core.Plugins
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"An exception occured while unloading {instance.DisplayName}");
+                    m_Logger.LogError(ex, "An exception occured while unloading {DisplayName}", instance.DisplayName);
                 }
             }
 
             m_ActivatedPlugins.Clear();
-            m_Logger.LogInformation($"> {i} plugins unloaded.");
+            m_Logger.LogInformation("> {Count} plugins unloaded", i);
         }
     }
 }

--- a/framework/OpenMod.Core/Plugins/PluginAssemblyStore.cs
+++ b/framework/OpenMod.Core/Plugins/PluginAssemblyStore.cs
@@ -8,7 +8,6 @@ using OpenMod.NuGet;
 using Semver;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -81,7 +80,9 @@ namespace OpenMod.Core.Plugins
 
                 if (packages == null || packages.Count == 0) return newPlugins;
 
-                m_Logger.LogInformation($"Found and installing embedded NuGet packages for plugin assembly: {assembly.GetName().Name}");
+                m_Logger.LogInformation(
+                    "Found and installing embedded NuGet packages for plugin assembly: {AssemblyName}",
+                    assembly.GetName().Name);
 
                 var existingPackages = m_NuGetPackageManager.GetLoadedAssemblies();
 
@@ -105,7 +106,8 @@ namespace OpenMod.Core.Plugins
             catch (Exception ex)
             {
                 newPlugins.Clear();
-                m_Logger.LogError(ex, $"Failed to check/load embedded NuGet packages for assembly: {assembly}");
+                m_Logger.LogError(ex, "Failed to check/load embedded NuGet packages for assembly: {Assembly}",
+                    assembly);
             }
 
             return newPlugins;
@@ -125,7 +127,9 @@ namespace OpenMod.Core.Plugins
                 var pluginMetadata = providerAssembly.GetCustomAttribute<PluginMetadataAttribute>();
                 if (pluginMetadata == null)
                 {
-                    m_Logger.LogWarning($"No plugin metadata attribute found in assembly: {providerAssembly}; skipping loading of this assembly as plugin");
+                    m_Logger.LogWarning(
+                        "No plugin metadata attribute found in assembly: {ProviderAssembly}; skipping loading of this assembly as plugin",
+                        providerAssembly);
                     providerAssemblies.Remove(providerAssembly);
                     continue;
                 }
@@ -148,7 +152,9 @@ namespace OpenMod.Core.Plugins
                     var missingAssemblies = CheckRequiredDependencies(ex.LoaderExceptions);
                     if (!TryInstallMissingDependencies)
                     {
-                        m_Logger.LogWarning($"Couldn't load plugin from {providerAssembly}: Failed to resolve required dependencies: {string.Join(", ", missingAssemblies.Keys)}", Color.DarkRed);
+                        m_Logger.LogWarning(
+                            "Couldn't load plugin from {ProviderAssembly}: Failed to resolve required dependencies: {MissingAssemblies}",
+                            providerAssembly, string.Join(", ", missingAssemblies.Keys));
                         continue;
                     }
 
@@ -161,7 +167,9 @@ namespace OpenMod.Core.Plugins
                     continue;
                 }
 
-                m_Logger.LogWarning($"No {nameof(IOpenModPlugin)} implementation found in assembly: {providerAssembly}; skipping loading of this assembly as plugin");
+                m_Logger.LogWarning(
+                    "No {PluginInterfaceName} implementation found in assembly: {ProviderAssembly}; skipping loading of this assembly as plugin",
+                    nameof(IOpenModPlugin), providerAssembly);
                 providerAssemblies.Remove(providerAssembly);
             }
 
@@ -226,14 +234,16 @@ namespace OpenMod.Core.Plugins
                         continue;
                     }
 
-                    m_Logger.LogWarning($"Failed to install \"{assembly.Key}\": {result.Code}", Color.DarkRed);
+                    m_Logger.LogWarning("Failed to install \"{AssemblyName}\": {ResultCode}",
+                        assembly.Key, result.Code);
                 }
                 else
                 {
-                    m_Logger.LogWarning($"Package not found: {assembly.Key}", Color.DarkRed);
+                    m_Logger.LogWarning("Package not found: {AssemblyName}", assembly.Key);
                 }
 
-                m_Logger.LogWarning($"Plugin \"{providerAssembly.GetName().Name}\" can't load without it!", Color.DarkRed);
+                m_Logger.LogWarning("Plugin \"{ProviderAssemblyName}\" can't load without it!",
+                    providerAssembly.GetName().Name);
                 return;
             }
         }

--- a/framework/OpenMod.Core/Rcon/Source/SourceRconClient.cs
+++ b/framework/OpenMod.Core/Rcon/Source/SourceRconClient.cs
@@ -107,7 +107,7 @@ namespace OpenMod.Core.Rcon.Source
                     break;
 
                 default:
-                    m_Logger.LogDebug($"Received unknown packet: {packet.Type}");
+                    m_Logger.LogDebug("Received unknown packet: {PacketType}", packet.Type);
                     break;
             }
         }

--- a/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconClient.cs
+++ b/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconClient.cs
@@ -151,7 +151,7 @@ namespace OpenMod.Core.Rcon.Tcp
                         }
                         catch (Exception ex)
                         {
-                            m_Logger.LogError(ex, $"{DisplayName} caused exception");
+                            m_Logger.LogError(ex, "{DisplayName} caused exception", DisplayName);
                             await SendMessageAsync(ex.Message, cancellationToken);
                         }
                     }

--- a/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconHost.cs
+++ b/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconHost.cs
@@ -62,7 +62,8 @@ namespace OpenMod.Core.Rcon.Tcp
                 try
                 {
                     m_Listener.Start();
-                    m_Logger.LogInformation($"{GetType().Name} started listening on {Bind.Address}:{Bind.Port}.");
+                    m_Logger.LogInformation("{Type} started listening on {IPAddress}:{Port}",
+                        GetType().Name, Bind.Address, Bind.Port);
 
                     while (true)
                     {
@@ -150,7 +151,7 @@ namespace OpenMod.Core.Rcon.Tcp
                     m_IsStopped = true;
                 }
 
-                m_Logger.LogInformation($"{GetType().Name} stopped.");
+                m_Logger.LogInformation("{Type} stopped", GetType().Name);
             }, cancellationToken);
 
             m_ListenerTask = task;

--- a/framework/OpenMod.EntityFrameworkCore/OpenModDbContext.cs
+++ b/framework/OpenMod.EntityFrameworkCore/OpenModDbContext.cs
@@ -95,12 +95,13 @@ namespace OpenMod.EntityFrameworkCore
             if (string.IsNullOrEmpty(TablePrefix))
             {
                 return;
-            } 
+            }
 
             foreach (var entityType in modelBuilder.Model.GetEntityTypes())
             {
                 var name = TablePrefix + entityType.GetTableName();
-                m_Logger.LogDebug($"Applying table name convention: {entityType.GetTableName()} -> {name}");
+                m_Logger.LogDebug("Applying table name convention: {TableName} -> {NewTableName}",
+                    entityType.GetTableName(), name);
                 entityType.SetTableName(name);
             }
         }

--- a/framework/OpenMod.Runtime/OpenModHostedService.cs
+++ b/framework/OpenMod.Runtime/OpenModHostedService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -54,7 +55,8 @@ namespace OpenMod.Runtime
             await m_PermissionChecker.InitAsync();
             Smart.Default.Parser.UseAlternativeEscapeChar();// '\\' is the default value
 
-            m_Logger.LogInformation($"Initializing for host: {m_HostInformation.HostName} v{m_HostInformation.HostVersion}");
+            m_Logger.LogInformation("Initializing for host: {HostName} v{HostVersion}",
+                m_HostInformation.HostName, m_HostInformation.HostVersion);
             await m_Host.InitAsync();
 
             foreach (var assembly in m_Runtime.HostAssemblies)
@@ -73,7 +75,7 @@ namespace OpenMod.Runtime
                 }
             }
 
-            m_Logger.LogInformation($"> {i} plugins loaded.");
+            m_Logger.LogInformation("> {Count} plugins loaded", i);
 
             AsyncHelper.Schedule("OpenMod initialize event", () => m_EventBus.EmitAsync(m_Host, this, new OpenModInitializedEvent(m_Host)));
             await m_JobScheduler.StartAsync();

--- a/framework/OpenMod.Runtime/OpenModStartup.cs
+++ b/framework/OpenMod.Runtime/OpenModStartup.cs
@@ -68,7 +68,7 @@ namespace OpenMod.Runtime
             var assemblyName = assembly.GetName();
             if (m_RegisteredAssemblies.Contains(assembly.GetName()))
             {
-                m_Logger.LogDebug("Skipping already registered assembly: " + assemblyName);
+                m_Logger.LogDebug("Skipping already registered assembly: {AssemblyName}", assemblyName);
                 return;
             }
 
@@ -93,10 +93,10 @@ namespace OpenMod.Runtime
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"Failed to copy resources from assembly: {assembly}");
+                    m_Logger.LogError(ex, "Failed to copy resources from assembly: {Assembly}", assembly);
                 }
             }
-            
+
             foreach (var assembly in assemblies)
             {
                 // Auto register services with [Service] and [ServiceImplementation] attributes
@@ -106,7 +106,7 @@ namespace OpenMod.Runtime
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"Failed to load services from assembly: {assembly}");
+                    m_Logger.LogError(ex, "Failed to load services from assembly: {Assembly}", assembly);
                 }
             }
 
@@ -129,8 +129,8 @@ namespace OpenMod.Runtime
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex,
-                        $"Failed to configure configuration from: {configurationConfiguratorType.FullName}");
+                    m_Logger.LogError(ex, "Failed to configure configuration from: {ConfiguratorType}",
+                        configurationConfiguratorType.FullName);
                 }
             }
         }
@@ -156,7 +156,8 @@ namespace OpenMod.Runtime
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"Failed to configure container from: {containerConfiguratorType.FullName}");
+                    m_Logger.LogError(ex, "Failed to configure container from: {ConfiguratorType}",
+                        containerConfiguratorType.FullName);
                 }
             }
         }
@@ -189,7 +190,8 @@ namespace OpenMod.Runtime
                 }
                 catch (Exception ex)
                 {
-                    m_Logger.LogError(ex, $"Failed to configure services from: {serviceConfiguratorType.FullName}");
+                    m_Logger.LogError(ex, "Failed to configure services from: {ConfiguratorType}",
+                        serviceConfiguratorType.FullName);
                 }
             }
 

--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -131,7 +131,7 @@ namespace OpenMod.Runtime
 
                 SetupSerilog();
 
-                m_Logger.LogInformation($"OpenMod v{Version} is starting...");
+                m_Logger.LogInformation("OpenMod v{Version} is starting...", Version);
 
                 if (parameters.PackageManager is not NuGetPackageManager nugetPackageManager)
                 {
@@ -187,7 +187,9 @@ namespace OpenMod.Runtime
                                 hotReloadingEnabled = parsed;
                                 break;
                             default:
-                                m_Logger.LogWarning("Unknown config for 'hotreloading' in OpenMod configuration: " + unparsed);
+                                m_Logger.LogWarning(
+                                    "Unknown config for 'hotreloading' in OpenMod configuration: {UnparsedConfig}",
+                                    unparsed);
                                 break;
                         }
                     }
@@ -207,7 +209,9 @@ namespace OpenMod.Runtime
                                     tryInstallMissingDependencies = parsed;
                                     break;
                                 default:
-                                    m_Logger.LogWarning("Unknown config for 'tryAutoInstallMissingDependencies' in OpenMod configuration: " + unparsed);
+                                    m_Logger.LogWarning(
+                                        "Unknown config for 'tryAutoInstallMissingDependencies' in OpenMod configuration: {UnparsedConfig}",
+                                        unparsed);
                                     break;
                             }
                         }
@@ -268,7 +272,7 @@ namespace OpenMod.Runtime
                 catch (Exception ex)
                 {
                     Status = RuntimeStatus.Crashed;
-                    m_Logger.LogCritical(ex, "OpenMod has crashed.");
+                    m_Logger.LogCritical(ex, "OpenMod has crashed");
                     Log.CloseAndFlush();
                 }
 

--- a/samples/UserDatabasePlugin/UserDatabasePlugin.cs
+++ b/samples/UserDatabasePlugin/UserDatabasePlugin.cs
@@ -7,9 +7,9 @@ using OpenMod.Core.Plugins;
 using OpenMod.EntityFrameworkCore.Extensions;
 using UserDatabasePlugin.Database;
 
-[assembly: PluginMetadata("UserDatabasePlugin", 
-    Author = "OpenMod", 
-    DisplayName = "User Database Plugin", 
+[assembly: PluginMetadata("UserDatabasePlugin",
+    Author = "OpenMod",
+    DisplayName = "User Database Plugin",
     Website = "https://github.com/openmod/openmod/tree/main/samples/UserDatabasePlugin")]
 
 namespace UserDatabasePlugin
@@ -35,7 +35,7 @@ namespace UserDatabasePlugin
         {
             await m_DbContext.OpenModMigrateAsync();
 
-            m_Logger.LogInformation("UserDatabase has been loaded.");
+            m_Logger.LogInformation("UserDatabase has been loaded");
 
             // this is actually just a silly demo for permission registrations
             // the full permission which the user will see and manage will be "UserDatabasePlugin:anonymous" because RegisterPermission prefixes it with plugin ID

--- a/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
+++ b/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
@@ -47,7 +47,7 @@ namespace OpenMod.UnityEngine
 
             if (!m_ShutdownBlock.WaitOne(m_HostOptions.ShutdownTimeout))
             {
-                m_Logger.LogInformation("Waiting for the host to be disposed. Ensure all 'IHost' instances are wrapped in 'using' blocks.");
+                m_Logger.LogInformation("Waiting for the host to be disposed. Ensure all 'IHost' instances are wrapped in 'using' blocks");
             }
 
             m_ShutdownBlock.WaitOne();

--- a/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
+++ b/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
@@ -93,7 +93,7 @@ namespace OpenMod.Unturned.Commands
                 var ident = await m_PackageManager.QueryPackageExactAsync(assembly.GetName().Name, null, isPre);
                 if (ident == null)
                 {
-                    m_Logger.LogWarning($"No package found for assembly: {assembly.FullName}");
+                    m_Logger.LogWarning("No package found for assembly: {AssemblyName}", assembly.FullName);
                     continue;
                 }
 

--- a/unturned/OpenMod.Unturned/Logging/OpenModConsoleInputOutput.cs
+++ b/unturned/OpenMod.Unturned/Logging/OpenModConsoleInputOutput.cs
@@ -48,7 +48,7 @@ namespace OpenMod.Unturned.Logging
             System.Console.InputEncoding = encoding;
 
             m_PreviousConsoleIn = System.Console.In;
-            
+
             var enableHistory = m_Configuration.GetSection("console:history").Get<bool>();
             var enableAutoComplete = m_Configuration.GetSection("console:autocomplete").Get<bool>();
 
@@ -107,7 +107,7 @@ namespace OpenMod.Unturned.Logging
                         if (!string.IsNullOrWhiteSpace(command))
                         {
                             // Enqueue command because inputCommitted is expected on main thread/
-                            m_CommandQueue.Enqueue(command); 
+                            m_CommandQueue.Enqueue(command);
                         }
                     }
                 }
@@ -122,16 +122,19 @@ namespace OpenMod.Unturned.Logging
 
         public void outputInformation(string information)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_Logger.LogInformation(information);
         }
 
         public void outputWarning(string warning)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_Logger.LogWarning(warning);
         }
 
         public void outputError(string error)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_Logger.LogError(error);
         }
     }

--- a/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
+++ b/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
@@ -174,7 +174,8 @@ namespace OpenMod.Unturned
 
             Dedicator.commandWindow.addIOHandler(m_OpenModIoHandler);
 
-            m_Logger.LogInformation($"OpenMod for Unturned v{m_HostInformation.HostVersion} is initializing...");
+            m_Logger.LogInformation("OpenMod for Unturned v{HostVersion} is initializing...",
+                m_HostInformation.HostVersion);
 
             TlsWorkaround.Install();
 
@@ -194,7 +195,7 @@ namespace OpenMod.Unturned
                 s_UniTaskInited = true;
             }
 
-            m_Logger.LogInformation("OpenMod for Unturned is ready.");
+            m_Logger.LogInformation("OpenMod for Unturned is ready");
 
             return Task.CompletedTask;
             // ReSharper restore PossibleNullReferenceException

--- a/unturned/OpenMod.Unturned/RocketMod/RocketModIntegration.cs
+++ b/unturned/OpenMod.Unturned/RocketMod/RocketModIntegration.cs
@@ -159,7 +159,7 @@ namespace OpenMod.Unturned.RocketMod
                 return;
             }
 
-            m_Logger.LogInformation("RocketMod is installed, enabling RocketMod integration.");
+            m_Logger.LogInformation("RocketMod is installed, enabling RocketMod integration");
 
             m_HarmonyInstance = new Harmony(c_HarmonyId);
             m_HarmonyInstance.PatchAllConditional(typeof(OpenModUnturnedHost).Assembly, "rocketmod");
@@ -223,20 +223,21 @@ namespace OpenMod.Unturned.RocketMod
 
         private void OnRocketLog(LogLevel level, string message, Exception? ex)
         {
+            // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
             m_RocketModLogger.Log(level, ex, message);
         }
 
         private void OnRocketModIntialized()
         {
             AsyncHelper.RunSync(async () => await m_EventBus.EmitAsync(m_RocketModComponent, this, new RocketModInitializedEvent()));
-            m_Logger.LogInformation("RocketMod is ready.");
+            m_Logger.LogInformation("RocketMod is ready");
             s_IsReady = true;
         }
 
         private void OnRocketModPluginsLoaded()
         {
             AsyncHelper.RunSync(async () => await m_EventBus.EmitAsync(m_RocketModComponent, this, new RocketModPluginsLoadedEvent()));
-            m_Logger.LogInformation("RocketMod plugins have been loaded.");
+            m_Logger.LogInformation("RocketMod plugins have been loaded");
         }
 
         /// <summary>

--- a/unturned/OpenMod.Unturned/RocketMod/RocketModPluginsLoadedEventListener.cs
+++ b/unturned/OpenMod.Unturned/RocketMod/RocketModPluginsLoadedEventListener.cs
@@ -103,7 +103,7 @@ namespace OpenMod.Unturned.RocketMod
                 else
                 {
                     var logger = m_LoggerFactory.CreateLogger<RocketModIntegration>();
-                    logger.LogWarning("Economy system was set to OpenMod_Uconomy but Uconomy is not loaded. Defaulting to Separate.");
+                    logger.LogWarning("Economy system was set to OpenMod_Uconomy but Uconomy is not loaded. Defaulting to Separate");
                 }
             }
 

--- a/unturned/OpenMod.Unturned/ServiceConfigurator.cs
+++ b/unturned/OpenMod.Unturned/ServiceConfigurator.cs
@@ -89,7 +89,7 @@ namespace OpenMod.Unturned
                     else
                     {
                         var logger = openModStartupContext.LoggerFactory.CreateLogger<RocketModIntegration>();
-                        logger.LogWarning("Economy system was set to RocketMod_Uconomy but Uconomy is not installed. Defaulting to Separate.");
+                        logger.LogWarning("Economy system was set to RocketMod_Uconomy but Uconomy is not installed. Defaulting to Separate");
                     }
                 }
             }


### PR DESCRIPTION
All logger calls now conform the following rules:
* https://github.com/olsh/resharper-structured-logging/blob/master/rules/TemplateIsNotCompileTimeConstantProblem.md
* https://github.com/olsh/resharper-structured-logging/blob/master/rules/LogMessageIsSentenceProblem.md

Some calls use strings provided by external sources and can't be adjusted so I left them as is

Fixed calls:
* in `PluginAssemblyStore` that were trying to add `Color.DarkRed` (leftovers from legacy code I believe)
* warning log call in `ServiceRegistrationHelper` - exception argument in wrong position

Misc:
* removed some unused imports
* changed `AssemblyHelper.CopyAssemblyResources` `string baseDir` parameter to `string?`