### PR TITLE
Load plugin's debug symbols

### DIFF
--- a/framework/OpenMod.Common/Helpers/FileHelper.cs
+++ b/framework/OpenMod.Common/Helpers/FileHelper.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OpenMod.Common.Helpers
+{
+    internal static class FileHelper
+    {
+        internal static async Task<byte[]> ReadAllBytesAsync(string path)
+        {
+            using var stream = File.Open(path, FileMode.Open);
+            var buffer = new byte[stream.Length];
+            await stream.ReadAsync(buffer, offset: 0, count: (int) stream.Length);
+            return buffer;
+        }
+    }
+}

--- a/framework/OpenMod.Common/Helpers/StreamHelper.cs
+++ b/framework/OpenMod.Common/Helpers/StreamHelper.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace OpenMod.Common.Helpers
+{
+    internal static class StreamHelper
+    {
+        internal static byte[] ReadAllBytes(this Stream stream)
+        {
+            if (stream is MemoryStream memoryStream)
+            {
+                return memoryStream.ToArray();
+            }
+
+            using var newMemoryStream = new MemoryStream();
+            stream.CopyTo(newMemoryStream);
+            return newMemoryStream.ToArray();
+        }
+    }
+}

--- a/framework/OpenMod.Common/OpenMod.Common.csproj
+++ b/framework/OpenMod.Common/OpenMod.Common.csproj
@@ -6,9 +6,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>OpenMod.Core</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>OpenMod.NuGet</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="dnlib" Version="3.3.2" />
   </ItemGroup>
-  
+
   <Import Project="$(MSBuildThisFileDirectory)..\..\props\SharedProjectProps.props" />
 
 </Project>

--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -146,7 +146,7 @@ namespace OpenMod.Runtime
 
                 await nugetPackageManager.RemoveOutdatedPackagesAsync();
                 nugetPackageManager.InstallAssemblyResolver();
-                nugetPackageManager.SetAssemblyLoader(Hotloader.LoadAssembly);
+                nugetPackageManager.SetAssemblyLoader((NuGetPackageManager.AssemblyLoader) Hotloader.LoadAssembly);
 
                 var startupContext = new OpenModStartupContext
                 {


### PR DESCRIPTION
Allows debugging plugins that have .pdb file next to .dll