### PR TITLE
Resource events

### DIFF
--- a/unturned/OpenMod.Unturned/Resources/Events/ResourcesEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Resources/Events/ResourcesEventsListener.cs
@@ -19,7 +19,6 @@ namespace OpenMod.Unturned.Resources.Events
     [UsedImplicitly]
     internal class ResourcesEventsListener : UnturnedEventsListener
     {
-
         public ResourcesEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
         {
         }
@@ -33,8 +32,8 @@ namespace OpenMod.Unturned.Resources.Events
             ResourceManager.onDamageResourceRequested -= OnDamageResourceRequested;
         }
 
-        private void OnDamageResourceRequested(CSteamID instigatorSteamId, Transform objectTransform, ref ushort pendingTotalDamage,
-            ref bool shouldAllow, EDamageOrigin damageOrigin)
+        private void OnDamageResourceRequested(CSteamID instigatorSteamId, Transform objectTransform, // lgtm [cs/too-many-ref-parameters]
+            ref ushort pendingTotalDamage, ref bool shouldAllow, EDamageOrigin damageOrigin)
         {
             if (!ResourceManager.tryGetRegion(objectTransform, out byte x, out byte y, out ushort index))
             {

--- a/unturned/OpenMod.Unturned/Resources/Events/ResourcesEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Resources/Events/ResourcesEventsListener.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+using OpenMod.API;
+using OpenMod.Unturned.Events;
+using OpenMod.Unturned.Players;
+
+using SDG.Unturned;
+
+using Steamworks;
+
+using UnityEngine;
+
+namespace OpenMod.Unturned.Resources.Events
+{
+    [OpenModInternal]
+    [UsedImplicitly]
+    internal class ResourcesEventsListener : UnturnedEventsListener
+    {
+
+        public ResourcesEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        public override void Subscribe() {
+            ResourceManager.onDamageResourceRequested += OnDamageResourceRequested;
+        }
+
+        public override void Unsubscribe()
+        {
+            ResourceManager.onDamageResourceRequested -= OnDamageResourceRequested;
+        }
+
+        private void OnDamageResourceRequested(CSteamID instigatorSteamId, Transform objectTransform, ref ushort pendingTotalDamage,
+            ref bool shouldAllow, EDamageOrigin damageOrigin)
+        {
+            if (!ResourceManager.tryGetRegion(objectTransform, out byte x, out byte y, out ushort index))
+            {
+                return;
+            }
+
+            List<ResourceSpawnpoint> tree = LevelGround.trees[x, y];
+            ResourceSpawnpoint spawnpoint = tree[index];
+
+            Player? nativePlayer = PlayerTool.getPlayer(instigatorSteamId);
+            UnturnedPlayer? player = GetUnturnedPlayer(nativePlayer);
+
+            var @event = new UnturnedResourceDamagingEvent(spawnpoint, pendingTotalDamage, damageOrigin, player, instigatorSteamId)
+            {
+                IsCancelled = !shouldAllow
+            };
+
+            Emit(@event);
+
+            pendingTotalDamage = @event.DamageAmount;
+            shouldAllow = !@event.IsCancelled;
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Resources/Events/UnturnedResourceDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Resources/Events/UnturnedResourceDamagingEvent.cs
@@ -1,0 +1,37 @@
+using OpenMod.API.Eventing;
+using OpenMod.Core.Eventing;
+using OpenMod.Unturned.Players;
+
+using SDG.Unturned;
+
+using Steamworks;
+
+namespace OpenMod.Unturned.Resources.Events {
+
+    public class UnturnedResourceDamagingEvent : Event, ICancellableEvent
+    {
+
+        public ResourceSpawnpoint ResourceSpawnpoint { get; }
+
+        public ushort DamageAmount { get; set; }
+
+        public EDamageOrigin DamageOrigin { get; }
+
+        public UnturnedPlayer? Instigator { get; }
+
+        public CSteamID InstigatorId { get; }
+
+        public bool IsCancelled { get; set; }
+
+        public UnturnedResourceDamagingEvent(ResourceSpawnpoint resourceSpawnpoint, ushort damageAmount, EDamageOrigin damageOrigin,
+            UnturnedPlayer? instigator, CSteamID instigatorId)
+        {
+            ResourceSpawnpoint = resourceSpawnpoint;
+            DamageAmount = damageAmount;
+            DamageOrigin = damageOrigin;
+            Instigator = instigator;
+            InstigatorId = instigatorId;
+        }
+    }
+
+}

--- a/unturned/OpenMod.Unturned/Resources/Events/UnturnedResourceDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Resources/Events/UnturnedResourceDamagingEvent.cs
@@ -6,11 +6,10 @@ using SDG.Unturned;
 
 using Steamworks;
 
-namespace OpenMod.Unturned.Resources.Events {
-
+namespace OpenMod.Unturned.Resources.Events
+{
     public class UnturnedResourceDamagingEvent : Event, ICancellableEvent
     {
-
         public ResourceSpawnpoint ResourceSpawnpoint { get; }
 
         public ushort DamageAmount { get; set; }
@@ -33,5 +32,4 @@ namespace OpenMod.Unturned.Resources.Events {
             InstigatorId = instigatorId;
         }
     }
-
 }


### PR DESCRIPTION
A single event from ResourceManager
This exposes `ResourceSpawnpoint`, it should be fine since there is no resource abstraction currently or planned afaik