### PR TITLE
Fix performance issue with FileSystemWatcher on Mono

### DIFF
--- a/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
+++ b/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizerFactory.cs
@@ -34,11 +34,16 @@ namespace OpenMod.Core.Localization
                 .AddYamlFile(baseName + ".yaml", true, reloadOnChange: true)
                 .Build();
 
-            var reloadToken = translations.GetReloadToken();
-            reloadToken.RegisterChangeCallback(_ =>
+            void ReloadToken()
             {
-                m_Logger.LogInformation("Reloading translations: {Path}", Path.Combine(location, baseName + ".yaml"));
-            }, null);
+                translations.GetReloadToken().RegisterChangeCallback(_ =>
+                {
+                    m_Logger.LogInformation("Reloading translations: {Path}", Path.Combine(location, baseName + ".yaml"));
+                    ReloadToken();
+                }, null);
+            }
+
+            ReloadToken();
 
             return new ConfigurationBasedStringLocalizer(translations);
         }

--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -283,12 +283,12 @@ namespace OpenMod.Runtime
                     var watcherField = typeof(FileSystemWatcher).GetField("watcher", BindingFlags.Static | BindingFlags.NonPublic);
                     var watcher = watcherField?.GetValue(null);
 
-                    if (watcher?.GetType().GetField("watches", BindingFlags.Static | BindingFlags.NonPublic).GetValue(watcher) is Hashtable hashtable)
+                    if (watcher?.GetType().GetField("watches", BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(watcher) is Hashtable watches)
                     {
                         FieldInfo? incSubdirsField = null;
 
                         // DictionaryEntry<FileSystemWatcher, DefaultWatcherData>
-                        foreach (var data in hashtable)
+                        foreach (var data in watches)
                         {
                             if (data is DictionaryEntry entry)
                             {

--- a/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
+++ b/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
@@ -198,7 +198,7 @@ namespace OpenMod.Unturned
                     ?? throw new Exception("Could not find PlayerLoopHelper.mainThreadId field");
                 mainThreadIdField.SetValue(null, Thread.CurrentThread.ManagedThreadId);
 
-                var playerLoop = PlayerLoop.GetDefaultPlayerLoop();
+                var playerLoop = PlayerLoop.GetCurrentPlayerLoop();
                 PlayerLoopHelper.Initialize(ref playerLoop);
                 s_UniTaskInited = true;
             }


### PR DESCRIPTION
- Fixed performance issue with FileSystemWatcher on Unity Mono Windows
- Unturned UniTask: switched GetDefaultPlayerLoop to GetCurrentPlayerLoop
- Re-registering the change token on reload callback