### PR TITLE
Added some new events for Player Quests.

### DIFF
--- a/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
@@ -1,0 +1,36 @@
+﻿extern alias JetBrainsAnnotations;
+using JetBrainsAnnotations::JetBrains.Annotations;
+using OpenMod.Unturned.Events;
+using SDG.Unturned;
+using Steamworks;
+using System;
+
+namespace OpenMod.Unturned.Players.Quests.Events
+{
+    [UsedImplicitly]
+    internal abstract class PlayerQuestsEventsListener : UnturnedPlayerEventsListener
+    {
+        public PlayerQuestsEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        public override void Subscribe()
+        {
+            PlayerQuests.onGroupChanged += OnGroupChanged;
+        }
+
+        private void OnGroupChanged(PlayerQuests sender, CSteamID oldGroupID, EPlayerGroupRank oldGroupRank, CSteamID newGroupID, EPlayerGroupRank newGroupRank)
+        {
+            var player = GetUnturnedPlayer(sender.player)!;
+
+            var @event = new UnturnedPlayerGroupChangedEvent(player, oldGroupID, oldGroupRank, newGroupID, newGroupRank);
+
+            Emit(@event);
+        }
+
+        public override void Unsubscribe()
+        {
+            PlayerQuests.onGroupChanged -= OnGroupChanged;
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
@@ -10,7 +10,7 @@ namespace OpenMod.Unturned.Players.Quests.Events
     [UsedImplicitly]
     internal class PlayerQuestsEventsListener : UnturnedPlayerEventsListener
     {
-        protected PlayerQuestsEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
+        public PlayerQuestsEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
         {
         }
 

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
@@ -8,29 +8,64 @@ using System;
 namespace OpenMod.Unturned.Players.Quests.Events
 {
     [UsedImplicitly]
-    internal abstract class PlayerQuestsEventsListener : UnturnedPlayerEventsListener
+    internal class PlayerQuestsEventsListener : UnturnedPlayerEventsListener
     {
-        public PlayerQuestsEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
+        protected PlayerQuestsEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
         {
         }
 
         public override void Subscribe()
         {
             PlayerQuests.onGroupChanged += OnGroupChanged;
-        }
-
-        private void OnGroupChanged(PlayerQuests sender, CSteamID oldGroupID, EPlayerGroupRank oldGroupRank, CSteamID newGroupID, EPlayerGroupRank newGroupRank)
-        {
-            var player = GetUnturnedPlayer(sender.player)!;
-
-            var @event = new UnturnedPlayerGroupChangedEvent(player, oldGroupID, oldGroupRank, newGroupID, newGroupRank);
-
-            Emit(@event);
+            PlayerQuests.onAnyFlagChanged += OnAnyFlagChanged;
         }
 
         public override void Unsubscribe()
         {
             PlayerQuests.onGroupChanged -= OnGroupChanged;
+            PlayerQuests.onAnyFlagChanged -= OnAnyFlagChanged;
+        }
+
+        public override void SubscribePlayer(Player player)
+        {
+            player.quests.groupRankChanged += OnGroupRankChanged;
+        }
+
+        public override void UnsubscribePlayer(Player player)
+        {
+            player.quests.groupRankChanged -= OnGroupRankChanged;
+        }
+
+        private void OnAnyFlagChanged(PlayerQuests quests, PlayerQuestFlag flag)
+        {
+            var player = GetUnturnedPlayer(quests.player)!;
+
+            var @event =
+                new UnturnedPlayerFlagChangedEvent(player, quests, flag);
+
+            Emit(@event);
+        }
+
+        private void OnGroupChanged(PlayerQuests sender, CSteamID oldGroupID, EPlayerGroupRank oldGroupRank,
+            CSteamID newGroupID, EPlayerGroupRank newGroupRank)
+        {
+            var player = GetUnturnedPlayer(sender.player)!;
+
+            var @event =
+                new UnturnedPlayerGroupChangedEvent(player, oldGroupID, oldGroupRank, newGroupID, newGroupRank);
+
+            Emit(@event);
+        }
+
+        private void OnGroupRankChanged(PlayerQuests sender, EPlayerGroupRank oldGroupRank,
+            EPlayerGroupRank newGroupRank)
+        {
+            var player = GetUnturnedPlayer(sender.player)!;
+
+            var @event =
+                new UnturnedPlayerGroupRankChangedEvent(player, oldGroupRank, newGroupRank);
+
+            Emit(@event);
         }
     }
 }

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/PlayerQuestsEventsListener.cs
@@ -41,18 +41,18 @@ namespace OpenMod.Unturned.Players.Quests.Events
             var player = GetUnturnedPlayer(quests.player)!;
 
             var @event =
-                new UnturnedPlayerFlagChangedEvent(player, quests, flag);
+                new UnturnedPlayerFlagChangedEvent(player, flag);
 
             Emit(@event);
         }
 
-        private void OnGroupChanged(PlayerQuests sender, CSteamID oldGroupID, EPlayerGroupRank oldGroupRank,
-            CSteamID newGroupID, EPlayerGroupRank newGroupRank)
+        private void OnGroupChanged(PlayerQuests sender, CSteamID oldGroupId, EPlayerGroupRank oldGroupRank,
+            CSteamID newGroupId, EPlayerGroupRank newGroupRank)
         {
             var player = GetUnturnedPlayer(sender.player)!;
 
             var @event =
-                new UnturnedPlayerGroupChangedEvent(player, oldGroupID, oldGroupRank, newGroupID, newGroupRank);
+                new UnturnedPlayerGroupChangedEvent(player, oldGroupId, oldGroupRank, newGroupId, newGroupRank);
 
             Emit(@event);
         }

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerFlagChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerFlagChangedEvent.cs
@@ -1,0 +1,19 @@
+﻿extern alias JetBrainsAnnotations;
+using OpenMod.Unturned.Events;
+using SDG.Unturned;
+
+namespace OpenMod.Unturned.Players.Quests.Events
+{
+    public class UnturnedPlayerFlagChangedEvent : UnturnedPlayerEvent
+    {
+        public PlayerQuests Quests { get; }
+        public PlayerQuestFlag Flag { get;  }
+
+        public UnturnedPlayerFlagChangedEvent(UnturnedPlayer player, PlayerQuests quests, PlayerQuestFlag flag) :
+            base(player)
+        {
+            Quests = quests;
+            Flag = flag;
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerFlagChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerFlagChangedEvent.cs
@@ -1,18 +1,15 @@
-﻿extern alias JetBrainsAnnotations;
-using OpenMod.Unturned.Events;
+﻿using OpenMod.Unturned.Events;
 using SDG.Unturned;
 
 namespace OpenMod.Unturned.Players.Quests.Events
 {
     public class UnturnedPlayerFlagChangedEvent : UnturnedPlayerEvent
     {
-        public PlayerQuests Quests { get; }
         public PlayerQuestFlag Flag { get;  }
 
-        public UnturnedPlayerFlagChangedEvent(UnturnedPlayer player, PlayerQuests quests, PlayerQuestFlag flag) :
+        public UnturnedPlayerFlagChangedEvent(UnturnedPlayer player, PlayerQuestFlag flag) :
             base(player)
         {
-            Quests = quests;
             Flag = flag;
         }
     }

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
@@ -19,6 +19,7 @@ namespace OpenMod.Unturned.Players.Quests.Events
             OldGroupID = oldGroupID;
             OldGroupRank = oldGroupRank;
             NewGroupID = newGroupID;
+            NewGroupRank = newGroupRank;
         }
     }
 }

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
@@ -1,0 +1,24 @@
+﻿extern alias JetBrainsAnnotations;
+using OpenMod.Unturned.Events;
+using SDG.Unturned;
+using Steamworks;
+
+namespace OpenMod.Unturned.Players.Quests.Events
+{
+    public class UnturnedPlayerGroupChangedEvent : UnturnedPlayerEvent
+    {
+        public CSteamID OldGroupID { get; }
+        public EPlayerGroupRank OldGroupRank { get;  }
+
+        public CSteamID NewGroupID { get; }
+        public EPlayerGroupRank NewGroupRank { get; }
+
+        public UnturnedPlayerGroupChangedEvent(UnturnedPlayer player, CSteamID oldGroupID,
+            EPlayerGroupRank oldGroupRank, CSteamID newGroupID, EPlayerGroupRank newGroupRank) : base(player)
+        {
+            OldGroupID = oldGroupID;
+            OldGroupRank = oldGroupRank;
+            NewGroupID = newGroupID;
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupChangedEvent.cs
@@ -1,5 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
-using OpenMod.Unturned.Events;
+﻿using OpenMod.Unturned.Events;
 using SDG.Unturned;
 using Steamworks;
 
@@ -7,18 +6,18 @@ namespace OpenMod.Unturned.Players.Quests.Events
 {
     public class UnturnedPlayerGroupChangedEvent : UnturnedPlayerEvent
     {
-        public CSteamID OldGroupID { get; }
+        public CSteamID OldGroupId { get; }
         public EPlayerGroupRank OldGroupRank { get;  }
 
-        public CSteamID NewGroupID { get; }
+        public CSteamID NewGroupId { get; }
         public EPlayerGroupRank NewGroupRank { get; }
 
-        public UnturnedPlayerGroupChangedEvent(UnturnedPlayer player, CSteamID oldGroupID,
-            EPlayerGroupRank oldGroupRank, CSteamID newGroupID, EPlayerGroupRank newGroupRank) : base(player)
+        public UnturnedPlayerGroupChangedEvent(UnturnedPlayer player, CSteamID oldGroupId,
+            EPlayerGroupRank oldGroupRank, CSteamID newGroupId, EPlayerGroupRank newGroupRank) : base(player)
         {
-            OldGroupID = oldGroupID;
+            OldGroupId = oldGroupId;
             OldGroupRank = oldGroupRank;
-            NewGroupID = newGroupID;
+            NewGroupId = newGroupId;
             NewGroupRank = newGroupRank;
         }
     }

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupRankChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupRankChangedEvent.cs
@@ -1,0 +1,20 @@
+﻿extern alias JetBrainsAnnotations;
+using OpenMod.Unturned.Events;
+using SDG.Unturned;
+
+namespace OpenMod.Unturned.Players.Quests.Events
+{
+    public class UnturnedPlayerGroupRankChangedEvent : UnturnedPlayerEvent
+    {
+        public EPlayerGroupRank OldGroupRank { get;  }
+
+        public EPlayerGroupRank NewGroupRank { get; }
+
+        public UnturnedPlayerGroupRankChangedEvent(UnturnedPlayer player, EPlayerGroupRank oldGroupRank,
+            EPlayerGroupRank newGroupRank) : base(player)
+        {
+            OldGroupRank = oldGroupRank;
+            NewGroupRank = newGroupRank;
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupRankChangedEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Quests/Events/UnturnedPlayerGroupRankChangedEvent.cs
@@ -1,5 +1,4 @@
-﻿extern alias JetBrainsAnnotations;
-using OpenMod.Unturned.Events;
+﻿using OpenMod.Unturned.Events;
 using SDG.Unturned;
 
 namespace OpenMod.Unturned.Players.Quests.Events


### PR DESCRIPTION
This is the list of the events I added:
PlayerQuests.onGroupChanged which is fired when a player changes/leaves/destroys a group.
player.quests.groupRankChanged which is fired when a players group rank is changed.
PlayerQuests.onAnyFlagChanged which is fired when a players flag is changed.