### PR TITLE
Fix stalling the server on player connect and disconnect

### DIFF
--- a/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUserProvider.cs
@@ -14,6 +14,7 @@ using OpenMod.UnityEngine.Extensions;
 using OpenMod.Unturned.Users.Events;
 using SDG.Unturned;
 using Steamworks;
+using Nito.AsyncEx;
 
 namespace OpenMod.Unturned.Users
 {
@@ -68,61 +69,51 @@ namespace OpenMod.Unturned.Users
             Provider.onRejectingPlayer += OnRejectingPlayer;
         }
 
-        protected virtual void OnPlayerConnected(CSteamID steamID)
+        private void OnPlayerConnected(CSteamID steamId)
         {
-            AsyncHelper.Schedule("OnPlayerConnected Event Thread", async () =>
+            var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == steamId);
+            if (pending != null)
             {
-                var steamPlayer = PlayerTool.getSteamPlayer(steamID);
-                if (steamPlayer == null || m_Users.Any(d => d.Player.SteamPlayer.Equals(steamPlayer)))
-                {
-                    return;
-                }
+                FinishSession(pending);
+            }
 
-                var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == steamPlayer.playerID.steamID);
-                if (pending != null)
-                {
-                    FinishSession(pending);
-                }
+            var steamPlayer = Provider.clients.FirstOrDefault(pl => pl.playerID.steamID == steamId);
+            if (steamPlayer == null)
+            {
+                return;
+            }
 
-                var user = new UnturnedUser(this, m_UserDataStore, steamPlayer.player, pending);
-                m_Users.Add(user);
+            var user = new UnturnedUser(this, m_UserDataStore, steamPlayer.player, pending);
+            m_Users.Add(user);
 
+            AsyncContext.Run(async () =>
+            {
                 var @event = new UnturnedUserConnectedEvent(user);
-
                 await m_EventBus.EmitAsync(m_Runtime, this, @event);
             });
         }
 
-        protected virtual void OnPlayerDisconnected(CSteamID steamID)
+        protected virtual void OnPlayerDisconnected(CSteamID steamId)
         {
-            AsyncHelper.Schedule("OnPlayerDisconnected Event Thread", async () =>
+            var user = GetUser(steamId);
+            if (user == null)
             {
-                var user = GetUser(steamID);
+                return;
+            }
 
-                if (user == null)
-                {
-                    return;
-                }
+            if (user.Session is UnturnedUserSession session)
+            {
+                session.OnSessionEnd();
+            }
 
-                if (user.Session is UnturnedUserSession session)
-                {
-                    session.OnSessionEnd();
-                }
-
+            AsyncHelper.RunSync(async () =>
+            {
                 var disconnectedEvent = new UnturnedUserDisconnectedEvent(user);
                 await m_EventBus.EmitAsync(m_Runtime, this, disconnectedEvent);
-
-                m_Users.Remove(user);
-
-                var userData = await m_UserDataStore.GetUserDataAsync(user.Id, user.Type);
-                if (userData == null)
-                {
-                    return;
-                }
-
-                userData.LastSeen = DateTime.Now;
-                await m_UserDataStore.SetUserDataAsync(userData);
             });
+
+            m_Users.Remove(user);
+            UpdateLastSeen(user.Id, user.Type);
         }
 
         public virtual UnturnedUser GetUser(Player player)
@@ -142,20 +133,29 @@ namespace OpenMod.Unturned.Users
 
         protected virtual void OnRejectingPlayer(CSteamID steamId, ESteamRejection rejection, string explanation)
         {
-            AsyncHelper.Schedule("OnRejectingPlayer Event Thread", async () =>
+            var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == steamId);
+            if (pending == null)
             {
-                var pending = m_PendingUsers.FirstOrDefault(d => d.SteamId == steamId);
-                if (pending == null)
-                {
-                    return;
-                }
+                return;
+            }
 
+            //This doesn't affect event
+            FinishSession(pending);
+
+            AsyncHelper.RunSync(async () =>
+            {
                 var disconnectedEvent = new UnturnedPendingUserDisconnectedEvent(pending);
                 await m_EventBus.EmitAsync(m_Runtime, this, disconnectedEvent);
+            });
 
-                FinishSession(pending);
+            UpdateLastSeen(pending.Id, pending.Type);
+        }
 
-                var userData = await m_UserDataStore.GetUserDataAsync(pending.Id, pending.Type);
+        private void UpdateLastSeen(string id, string type)
+        {
+            async UniTask UpdateDisconnectInfo()
+            {
+                var userData = await m_UserDataStore.GetUserDataAsync(id, type);
                 if (userData == null)
                 {
                     return;
@@ -163,70 +163,75 @@ namespace OpenMod.Unturned.Users
 
                 userData.LastSeen = DateTime.Now;
                 await m_UserDataStore.SetUserDataAsync(userData);
-            });
+            }
+
+            UpdateDisconnectInfo().Forget();
         }
 
         protected virtual void OnPendingPlayerConnecting(ValidateAuthTicketResponse_t callback, ref bool isValid,
             ref string? explanation)
         {
-            //todo check if it is working, if not this should be patched
+            var user = GetUser(callback.m_SteamID);
+            if (user != null || m_PendingUsers.Any(d => d.SteamId == callback.m_SteamID))
+            {
+                //User already in server?!
+                return;
+            }
+
+            var steamPending = Provider.pending.FirstOrDefault(d => d.playerID.steamID == callback.m_SteamID);
+            if (steamPending == null)
+            {
+                return;
+            }
+
+            var pendingUser = new UnturnedPendingUser(this, m_UserDataStore, steamPending);
+            m_PendingUsers.Add(pendingUser);
+
             var isPendingValid = isValid;
             var rejectExplanation = explanation;
-
-            AsyncHelper.Schedule("OnPendingPlayerConnecting Event Thread", async () =>
+            AsyncHelper.RunSync(async () =>
             {
-                if (m_PendingUsers.Any(d => d.SteamId == callback.m_SteamID))
-                {
-                    return;
-                }
+                UnturnedUserConnectingEvent userEvent;
 
-                var steamPending = Provider.pending.FirstOrDefault(d => d.playerID.steamID == callback.m_SteamID);
-                if (steamPending == null)
-                {
-                    return;
-                }
-
-                var pendingUser = new UnturnedPendingUser(this, m_UserDataStore, steamPending);
                 var userData = await m_UserDataStore.GetUserDataAsync(pendingUser.Id, pendingUser.Type);
-                var isFirstConnect = userData == null;
-
-                if (isFirstConnect)
+                if (userData != null)
                 {
-                    await m_DataSeeder.SeedUserDataAsync(pendingUser.Id, pendingUser.Type, pendingUser.DisplayName);
+                    userEvent = new UnturnedUserConnectingEvent(pendingUser);
+
+                    userData.LastSeen = DateTime.Now;
+                    userData.LastDisplayName = pendingUser.DisplayName;
+                    UniTask.Run(() => m_UserDataStore.SetUserDataAsync(userData)).Forget();
                 }
                 else
                 {
-                    userData ??= new();
-                    userData.LastSeen = DateTime.Now;
-                    userData.LastDisplayName = pendingUser.DisplayName;
-                    await m_UserDataStore.SetUserDataAsync(userData);
+                    userEvent = new UnturnedUserFirstConnectingEvent(pendingUser);
+                    UniTask.Run(() => m_DataSeeder.SeedUserDataAsync(pendingUser.Id, pendingUser.Type, pendingUser.DisplayName)).Forget();
                 }
 
-                m_PendingUsers.Add(pendingUser);
-
-                var userConnectingEvent = isFirstConnect
-                    ? new UnturnedUserFirstConnectingEvent(pendingUser)
-                    : new UnturnedUserConnectingEvent(pendingUser);
-
-                userConnectingEvent.IsCancelled = !isPendingValid;
+                userEvent.IsCancelled = !isPendingValid;
                 if (rejectExplanation != null)
-                    await userConnectingEvent.RejectAsync(rejectExplanation);
+                {
+                    await userEvent.RejectAsync(rejectExplanation);
+                }
 
-                await m_EventBus.EmitAsync(m_Runtime, this, userConnectingEvent);
-
-                if (!string.IsNullOrEmpty(userConnectingEvent.RejectionReason))
+                await m_EventBus.EmitAsync(m_Runtime, this, userEvent);
+                if (!string.IsNullOrEmpty(userEvent.RejectionReason))
                 {
                     isPendingValid = false;
-                    rejectExplanation = userConnectingEvent.RejectionReason;
+                    rejectExplanation = userEvent.RejectionReason;
                 }
-
-                if (userConnectingEvent.IsCancelled)
+                else if (userEvent.IsCancelled)
                 {
                     isPendingValid = false;
                 }
             });
             isValid = isPendingValid;
             explanation = rejectExplanation;
+
+            //Needed #413
+#pragma warning disable 618
+            Provider.onCheckValid?.Invoke(callback, ref isValid);
+#pragma warning restore 618
         }
 
         protected virtual void FinishSession(UnturnedPendingUser pending)
@@ -313,6 +318,7 @@ namespace OpenMod.Unturned.Users
 
         public Task BroadcastAsync(string userType, string message, System.Drawing.Color? color)
         {
+            // ReSharper disable once ConvertIfStatementToReturnStatement
             if (!KnownActorTypes.Player.Equals(userType, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.CompletedTask;


### PR DESCRIPTION
The events `OnPlayerConnected`, `OnPlayerDisconnected`, `OnRejectingPlayer`, and `OnPendingPlayerConnecting` get the user information on the main thread and stall the server. This isn't noticeable if you only have a few users in your openmod.users.yaml file, but when there are thousands of users in the file, then it will cause a massive lag spike whenever someone joins or leaves.

I've changed the event code to run on a different thread using AsyncHelper.Schedule(), and it's been working great on my servers.

I have also added the changes from #529.