### PR TITLE
Fix docs sidebar category item formatting

### DIFF
--- a/docs/templates/discordfx/partials/li.tmpl.partial
+++ b/docs/templates/discordfx/partials/li.tmpl.partial
@@ -11,7 +11,7 @@
             <a href="{{topicHref}}" class="sidebar-item" name="{{tocHref}}" title="{{name}}">{{name}}</a>
           {{/topicHref}}
           {{^topicHref}}
-            <a>{{{name}}}</a>
+            <a class="sidebar-item">{{{name}}}</a>
           {{/topicHref}}
         
         {{^leaf}}


### PR DESCRIPTION
Changes the sidebar from
![image](https://user-images.githubusercontent.com/16708907/124595405-5bd22b80-de37-11eb-84d0-c06118c58bda.png)
to
![image](https://user-images.githubusercontent.com/16708907/124595655-a9e72f00-de37-11eb-97e6-da99c45ba0d0.png)