### PR TITLE
Add overloads including event listener options to IEventBus

### DIFF
--- a/framework/OpenMod.API/Eventing/IEventBus.cs
+++ b/framework/OpenMod.API/Eventing/IEventBus.cs
@@ -44,6 +44,17 @@ namespace OpenMod.API.Eventing
         IDisposable Subscribe(IOpenModComponent component, string eventName, EventCallback callback);
 
         /// <summary>
+        /// Subscribes a component to an event.
+        /// </summary>
+        /// <param name="component">The component.</param>
+        /// <param name="eventName">The event to subscribe to.</param>
+        /// <param name="callback">The action to execute. See <see cref="EventCallback" /></param>
+        /// <param name="options">The extended options for this event subscription.</param>
+        /// <returns>A disposable that unsubscribes the callback when disposed.</returns>
+        IDisposable Subscribe(IOpenModComponent component, string eventName, EventCallback callback,
+            IEventListenerOptions options);
+
+        /// <summary>
         /// <inheritdoc cref="Subscribe(IOpenModComponent,string,EventCallback)" />
         /// </summary>
         /// <param name="component">The component.</param>
@@ -58,9 +69,31 @@ namespace OpenMod.API.Eventing
         /// </summary>
         /// <param name="component">The component.</param>
         /// <param name="callback">The action to execute after all listeners were notified.</param>
+        /// <param name="options">The extended options for this event subscription.</param>
+        /// <typeparam name="TEvent">The event to subscribe to.</typeparam>
+        /// <returns>A disposable that unsubscribes the callback when disposed.</returns>
+        IDisposable Subscribe<TEvent>(IOpenModComponent component, EventCallback<TEvent> callback,
+            IEventListenerOptions options) where TEvent : IEvent;
+
+        /// <summary>
+        /// <inheritdoc cref="Subscribe(IOpenModComponent,string,EventCallback)" />
+        /// </summary>
+        /// <param name="component">The component.</param>
         /// <param name="eventType">The event to subscribe to.</param>
+        /// <param name="callback">The action to execute after all listeners were notified.</param>
         /// <returns>A disposable that unsubscribes the callback when disposed.</returns>
         IDisposable Subscribe(IOpenModComponent component, Type eventType, EventCallback callback);
+
+        /// <summary>
+        /// <inheritdoc cref="Subscribe(IOpenModComponent,string,EventCallback)" />
+        /// </summary>
+        /// <param name="component">The component.</param>
+        /// <param name="eventType">The event to subscribe to.</param>
+        /// <param name="callback">The action to execute after all listeners were notified.</param>
+        /// <param name="options">The extended options for this event subscription.</param>
+        /// <returns>A disposable that unsubscribes the callback when disposed.</returns>
+        IDisposable Subscribe(IOpenModComponent component, Type eventType, EventCallback callback,
+            IEventListenerOptions options);
 
         /// <summary>
         /// Finds and registers all <see cref="IEventListener"/>s.

--- a/framework/OpenMod.API/Eventing/IEventListenerOptions.cs
+++ b/framework/OpenMod.API/Eventing/IEventListenerOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenMod.API.Eventing
+{
+    public interface IEventListenerOptions
+    {
+        EventListenerPriority Priority { get; }
+
+        bool IgnoreCancelled { get; }
+    }
+}

--- a/framework/OpenMod.Core/Eventing/EventListenerAttribute.cs
+++ b/framework/OpenMod.Core/Eventing/EventListenerAttribute.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using OpenMod.API.Eventing;
+using System;
 
 namespace OpenMod.Core.Eventing
 {
     [MeansImplicitUse]
     [AttributeUsage(AttributeTargets.Method)]
-    public class EventListenerAttribute : Attribute
+    public class EventListenerAttribute : Attribute, IEventListenerOptions
     {
         public EventListenerPriority Priority { get; set; } = EventListenerPriority.Normal;
 

--- a/framework/OpenMod.Core/Eventing/EventSubscription.cs
+++ b/framework/OpenMod.Core/Eventing/EventSubscription.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Reflection;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Microsoft.Extensions.DependencyInjection;
 using OpenMod.API;
 using OpenMod.API.Eventing;
 using OpenMod.Common.Helpers;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace OpenMod.Core.Eventing
 {
@@ -15,13 +15,13 @@ namespace OpenMod.Core.Eventing
         public EventSubscription(
             IOpenModComponent ownerComponent,
             EventCallback callback,
-            EventListenerAttribute attribute,
+            IEventListenerOptions options,
             string eventName,
             ILifetimeScope scope)
         {
             Owner = new WeakReference(ownerComponent);
             Callback = callback;
-            EventListenerAttribute = attribute;
+            EventListenerOptions = options;
             EventName = eventName;
             Scope = scope;
         }
@@ -30,7 +30,7 @@ namespace OpenMod.Core.Eventing
             IOpenModComponent ownerComponent,
             Type eventListener,
             MethodBase method,
-            EventListenerAttribute attribute,
+            IEventListenerOptions options,
             Type eventType,
             ILifetimeScope scope)
         {
@@ -41,7 +41,7 @@ namespace OpenMod.Core.Eventing
                 var listener = serviceProvider.GetRequiredService(eventListener);
                 return method.InvokeWithTaskSupportAsync(listener, new[] { sender, @event });
             };
-            EventListenerAttribute = attribute;
+            EventListenerOptions = options;
             EventName = eventType.Name;
             EventType = eventType;
             Scope = scope;
@@ -50,13 +50,13 @@ namespace OpenMod.Core.Eventing
         public EventSubscription(
             IOpenModComponent ownerComponent,
             EventCallback callback,
-            EventListenerAttribute attribute,
+            IEventListenerOptions options,
             Type eventType,
             ILifetimeScope scope)
         {
             Owner = new WeakReference(ownerComponent);
             Callback = callback;
-            EventListenerAttribute = attribute;
+            EventListenerOptions = options;
             EventName = eventType.Name;
             EventType = eventType;
             Scope = scope;
@@ -72,7 +72,7 @@ namespace OpenMod.Core.Eventing
 
         public EventCallback Callback { get; }
 
-        public EventListenerAttribute EventListenerAttribute { get; }
+        public IEventListenerOptions EventListenerOptions { get; }
 
         public Type? EventListener { get; }
 


### PR DESCRIPTION
Adds three new overloads to `IEventBus` to allow for manual passing of event listener options:
- `IDisposable Subscribe(IOpenModComponent, string, EventCallback, IEventListenerOptions);`
- `IDisposable Subscribe<TEvent>(IOpenModComponent, EventCallback<TEvent>, IEventListenerOptions)`
- `IDisposable Subscribe(IOpenModComponent, Type, EventCallback, IEventListenerOptions)`