### PR TITLE
Fix OpenMod crashing when plugins throws an error when unloading

### DIFF
--- a/framework/OpenMod.Core/Eventing/EventBus.cs
+++ b/framework/OpenMod.Core/Eventing/EventBus.cs
@@ -246,11 +246,6 @@ namespace OpenMod.Core.Eventing
                 }
             }));
 
-            scope.Disposer.AddInstanceForDisposal(new DisposeAction(() =>
-            {
-                m_EventSubscriptions.RemoveAll(x => x.Scope == scope);
-            }));
-
             var eventDisposables = new List<IDisposable>();
 
             foreach (var eventListener in eventListeners)

--- a/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
+++ b/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
@@ -39,8 +39,8 @@ namespace OpenMod.Core.Plugins
         public IEventBus EventBus { get; }
         protected ILogger Logger { get; set; } = null!;
         protected Harmony Harmony { get; private set; } = null!;
+
         private readonly IOptions<CommandStoreOptions> m_CommandStoreOptions;
-        private readonly ILoggerFactory m_LoggerFactory;
         private OpenModComponentCommandSource m_CommandSource = null!;
 
         protected OpenModPluginBase(IServiceProvider serviceProvider)
@@ -51,8 +51,10 @@ namespace OpenMod.Core.Plugins
             DataStore = serviceProvider.GetRequiredService<IDataStore>();
             Runtime = serviceProvider.GetRequiredService<IRuntime>();
             EventBus = serviceProvider.GetRequiredService<IEventBus>();
-            m_LoggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
             m_CommandStoreOptions = serviceProvider.GetRequiredService<IOptions<CommandStoreOptions>>();
+
+            var loggerType = typeof(ILogger<>).MakeGenericType(GetType());
+            Logger = (ILogger)serviceProvider.GetRequiredService(loggerType);
 
             var metadata = GetType().Assembly.GetCustomAttribute<PluginMetadataAttribute>();
             OpenModComponentId = metadata.Id;
@@ -76,7 +78,6 @@ namespace OpenMod.Core.Plugins
         [OpenModInternal]
         public virtual Task LoadAsync()
         {
-            Logger = m_LoggerFactory.CreateLogger(GetType());
             Logger.LogInformation("[loading] {DisplayName} v{Version}", DisplayName, Version);
 
             m_CommandSource = new OpenModComponentCommandSource(Logger, this, GetType().Assembly);

--- a/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
+++ b/framework/OpenMod.Core/Plugins/OpenModPluginBase.cs
@@ -114,9 +114,16 @@ namespace OpenMod.Core.Plugins
 
         public async ValueTask DisposeAsync()
         {
-            if (!await OnDispose())
+            try
             {
-                await UnloadAsync();
+                if (!await OnDispose())
+                {
+                    await UnloadAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Exception occurred when disposing plugin '{ComponentId}'", OpenModComponentId);
             }
 
             await EventBus.EmitAsync(this, this, new PluginDisposedEvent(this));

--- a/framework/OpenMod.Core/Plugins/PluginStatus.cs
+++ b/framework/OpenMod.Core/Plugins/PluginStatus.cs
@@ -1,0 +1,43 @@
+﻿namespace OpenMod.Core.Plugins
+{
+    /// <summary>
+    /// The loading status of an OpenMod plugin.
+    /// </summary>
+    public enum PluginStatus
+    {
+        /// <summary>
+        /// The plugin instance has been created but hasn't been loaded yet.
+        /// </summary>
+        Initialized,
+
+        /// <summary>
+        /// The plugin is loading, but has not yet finished.
+        /// </summary>
+        Loading,
+
+        /// <summary>
+        /// The plugin has finished loading.
+        /// </summary>
+        Loaded,
+
+        /// <summary>
+        /// The plugin is unloading, but has not yet finished.
+        /// </summary>
+        Unloading,
+
+        /// <summary>
+        /// The plugin has finished unloading.
+        /// </summary>
+        Unloaded,
+
+        /// <summary>
+        /// The plugin threw an exception during the loading process.
+        /// </summary>
+        ExceptionWhenLoading,
+
+        /// <summary>
+        /// The plugin threw an exception during the unloading process.
+        /// </summary>
+        ExceptionWhenUnloading
+    }
+}


### PR DESCRIPTION
#588 857fb822 fixes OpenMod failing to unload when a plugin's Unload method throws an error when unloading.

Added OpenModPluginBase.Status to allow for checking of the exact status of the plugin and added some load/unload checks to allow for more robusticity when it comes to calling Load/Unload.