### PR TITLE
Fix using static SmartFormatter. Use Zero allocation string builders

### DIFF
--- a/framework/OpenMod.Core/Commands/CommandContextExtensions.cs
+++ b/framework/OpenMod.Core/Commands/CommandContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using OpenMod.API.Commands;
+using SmartFormat.ZString;
 
 namespace OpenMod.Core.Commands
 {
@@ -7,7 +8,7 @@ namespace OpenMod.Core.Commands
     {
         public static string GetCommandLine(this ICommandContext context, bool includeArguments = true)
         {
-            var sb = new StringBuilder();
+            using var sb = new ZStringBuilder(false);
             sb.Append(context.CommandPrefix);
             sb.Append(context.CommandAlias);
 

--- a/framework/OpenMod.Core/Helpers/ArgumentsParser.cs
+++ b/framework/OpenMod.Core/Helpers/ArgumentsParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace OpenMod.Core.Helpers
@@ -12,18 +13,17 @@ namespace OpenMod.Core.Helpers
         /// <returns>The args[] array (argv)</returns>
         public static string[] ParseArguments(string line)
         {
-            var argsBuilder = new StringBuilder(line);
             var args = new List<string>();
 
-            var currentArg = new StringBuilder();
+            var currentArg = new StringBuilder(32);
 
             var inQuote = false;
             var inApostrophes = false;
             var isEscaped = false;
 
-            for (var i = 0; i < argsBuilder.Length; i++)
+            for (var i = 0; i < line.Length; i++)
             {
-                var currentChar = argsBuilder[i];
+                var currentChar = line[i];
                 if (isEscaped)
                 {
                     currentArg.Append(currentChar);
@@ -39,7 +39,7 @@ namespace OpenMod.Core.Helpers
                         break;
 
                     case '\'':
-                        if (!inQuote && (currentArg.Length == 0 || argsBuilder.Length == nextIndex || IsSpace(argsBuilder[nextIndex])))
+                        if (!inQuote && (currentArg.Length == 0 || line.Length == nextIndex || IsSpace(line[nextIndex])))
                         {
                             inApostrophes = !inApostrophes;
                         }
@@ -50,7 +50,7 @@ namespace OpenMod.Core.Helpers
                         break;
 
                     case '"':
-                        if (!inApostrophes && (currentArg.Length == 0 || argsBuilder.Length == nextIndex || IsSpace(argsBuilder[nextIndex])))
+                        if (!inApostrophes && (currentArg.Length == 0 || line.Length == nextIndex || IsSpace(line[nextIndex])))
                         {
                             inQuote = !inQuote;
                         }
@@ -106,6 +106,7 @@ namespace OpenMod.Core.Helpers
             return currentArg;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsSpace(char character)
         {
             return char.IsWhiteSpace(character) || character == char.MinValue;

--- a/framework/OpenMod.Core/Helpers/SmartFormatterHelper.cs
+++ b/framework/OpenMod.Core/Helpers/SmartFormatterHelper.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using SmartFormat;
+using SmartFormat.Extensions;
+
+namespace OpenMod.Core.Helpers
+{
+    public static class SmartFormatterHelper
+    {
+        // https://github.com/axuno/SmartFormat/wiki/Async-and-Thread-Safety
+        [ThreadStatic]
+        private static SmartFormatter? s_SmartFormatter;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SmartFormatter ObtainSmartFormatter()
+        {
+            return s_SmartFormatter ??= Smart.CreateDefaultSmartFormat().AddExtensions(new TimeFormatter());
+        }
+    }
+}

--- a/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizer.cs
+++ b/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizer.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Localization;
 using OpenMod.API;
-using SmartFormat;
+using OpenMod.Core.Helpers;
 
 namespace OpenMod.Core.Localization
 {
@@ -49,12 +49,9 @@ namespace OpenMod.Core.Localization
             get
             {
                 var configValue = m_Configuration.GetSection(name);
-                if (!configValue.Exists() || string.IsNullOrEmpty(configValue.Value))
-                {
-                    return new LocalizedString(name, name, true);
-                }
-
-                return new LocalizedString(name, configValue.Value);
+                return !configValue.Exists() || string.IsNullOrEmpty(configValue.Value)
+                    ? new LocalizedString(name, name, true)
+                    : new LocalizedString(name, configValue.Value);
             }
         }
 
@@ -68,7 +65,8 @@ namespace OpenMod.Core.Localization
                     return new LocalizedString(name, name, true);
                 }
 
-                return new LocalizedString(name, Smart.Format(configValue.Value, arguments));
+                var formatter = SmartFormatterHelper.ObtainSmartFormatter();
+                return new LocalizedString(name, formatter.Format(configValue.Value, arguments));
             }
         }
     }

--- a/framework/OpenMod.Core/Permissions/DefaultPermissionCheckProvider.cs
+++ b/framework/OpenMod.Core/Permissions/DefaultPermissionCheckProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using OpenMod.API.Permissions;
 using OpenMod.API.Prioritization;
 using OpenMod.Core.Helpers;
+using SmartFormat.ZString;
 
 namespace OpenMod.Core.Permissions
 {
@@ -112,7 +113,7 @@ namespace OpenMod.Core.Permissions
             // we will restore : later again
             permission = permission.Replace(":", ".");
 
-            var parentPath = new StringBuilder();
+            using var parentPath = new ZStringBuilder(false);
             foreach (var childPath in permission.Split('.'))
             {
                 permissions.Add($"{parentPath}{childPath}.*");

--- a/framework/OpenMod.Runtime/OpenModHostedService.cs
+++ b/framework/OpenMod.Runtime/OpenModHostedService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -11,6 +10,8 @@ using OpenMod.API.Plugins;
 using OpenMod.Core.Events;
 using OpenMod.Core.Helpers;
 using SmartFormat;
+using SmartFormat.Core.Settings;
+using SmartFormat.Extensions;
 
 namespace OpenMod.Runtime
 {
@@ -53,7 +54,10 @@ namespace OpenMod.Runtime
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             await m_PermissionChecker.InitAsync();
-            Smart.Default.Parser.UseAlternativeEscapeChar();// '\\' is the default value
+
+            // https://github.com/axuno/SmartFormat/wiki/Async-and-Thread-Safety
+            SmartSettings.IsThreadSafeMode = true;
+            Smart.Default = SmartFormatterHelper.ObtainSmartFormatter();
 
             m_Logger.LogInformation("Initializing for host: {HostName} v{HostVersion}",
                 m_HostInformation.HostName, m_HostInformation.HostVersion);

--- a/unturned/OpenMod.Unturned/Players/UnturnedPlayer.cs
+++ b/unturned/OpenMod.Unturned/Players/UnturnedPlayer.cs
@@ -11,6 +11,7 @@ using OpenMod.UnityEngine.Transforms;
 using OpenMod.Unturned.Items;
 using OpenMod.Unturned.Vehicles;
 using SDG.Unturned;
+using SmartFormat.ZString;
 using Steamworks;
 using System;
 using System.Collections.Generic;
@@ -243,17 +244,16 @@ namespace OpenMod.Unturned.Players
 
         private IEnumerable<string> WrapLine(string line)
         {
-            var words = line.Split(' ');
-            var lines = new List<string>();
-            var currentLine = new StringBuilder();
-            var maxLength = 90;
+            const int maxLength = 90;
 
-            foreach (var currentWord in words)
+            using var currentLine = new ZStringBuilder(false);
+
+            foreach (var currentWord in line.Split(' '))
             {
                 if (currentLine.Length > maxLength ||
                     currentLine.Length + currentWord.Length > maxLength)
                 {
-                    lines.Add(currentLine.ToString());
+                    yield return currentLine.ToString();
                     currentLine.Clear();
                 }
 
@@ -270,10 +270,8 @@ namespace OpenMod.Unturned.Players
 
             if (currentLine.Length > 0)
             {
-                lines.Add(currentLine.ToString());
+                yield return currentLine.ToString();
             }
-
-            return lines;
         }
 
         public Task SetHungerAsync(double hunger)

--- a/unturned/OpenMod.Unturned/Users/UnturnedUser.cs
+++ b/unturned/OpenMod.Unturned/Users/UnturnedUser.cs
@@ -1,15 +1,13 @@
-﻿using OpenMod.API;
+﻿using System;
+using System.Drawing;
+using System.Threading.Tasks;
+using OpenMod.API;
 using OpenMod.API.Users;
 using OpenMod.Core.Users;
 using OpenMod.Extensions.Games.Abstractions.Players;
 using OpenMod.Unturned.Players;
 using SDG.Unturned;
 using Steamworks;
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenMod.Unturned.Users
 {
@@ -60,49 +58,10 @@ namespace OpenMod.Unturned.Users
         {
             return Player.PrintMessageAsync(message, color, isRich, iconUrl);
         }
-            
-
-        private IEnumerable<string> WrapLine(string line)
-        {
-            var words = line.Split(' ');
-            var lines = new List<string>();
-            var currentLine = new StringBuilder();
-            var maxLength = 90;
-
-            foreach (var currentWord in words)
-            {
-                if ((currentLine.Length > maxLength) ||
-                    ((currentLine.Length + currentWord.Length) > maxLength))
-                {
-                    lines.Add(currentLine.ToString());
-                    currentLine.Clear();
-                }
-
-                if (currentLine.Length > 0)
-                {
-                    currentLine.Append(" ");
-                    currentLine.Append(currentWord);
-                }
-                else
-                {
-                    currentLine.Append(currentWord);
-                }
-            }
-
-            if (currentLine.Length > 0)
-            {
-                lines.Add(currentLine.ToString());
-            }
-
-            return lines;
-        }
 
         public bool Equals(UnturnedUser other)
         {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-
-            return other.SteamId.Equals(SteamId);
+            return !ReferenceEquals(null, other) && (ReferenceEquals(this, other) || other.SteamId.Equals(SteamId));
         }
 
         public bool Equals(UnturnedPendingUser other)


### PR DESCRIPTION
Using `Smart.Default` is not thread safely. So need to make 1 instance per thread (more info here: https://github.com/axuno/SmartFormat/wiki/Async-and-Thread-Safety ).

Also, with new version SmartFormat it's now include zero allocation string builders (ZString https://github.com/Cysharp/ZString ).



