### PR TITLE
Remove line wrapping at max 90 characters for Unturned chat messages

### DIFF
--- a/unturned/OpenMod.Unturned/Players/UnturnedPlayer.cs
+++ b/unturned/OpenMod.Unturned/Players/UnturnedPlayer.cs
@@ -11,15 +11,12 @@ using OpenMod.UnityEngine.Transforms;
 using OpenMod.Unturned.Items;
 using OpenMod.Unturned.Vehicles;
 using SDG.Unturned;
-using SmartFormat.ZString;
 using Steamworks;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Net;
 using System.Numerics;
-using System.Text;
 using System.Threading.Tasks;
 using Vector3 = System.Numerics.Vector3;
 
@@ -227,51 +224,16 @@ namespace OpenMod.Unturned.Players
                         continue;
                     }
 
-                    foreach (var lline in WrapLine(line))
-                    {
-                        ChatManager.serverSendMessage(
-                            text: lline,
-                            color: color.ToUnityColor(),
-                            toPlayer: SteamPlayer,
-                            iconURL: iconUrl,
-                            useRichTextFormatting: isRich);
-                    }
+                    ChatManager.serverSendMessage(
+                        text: line,
+                        color: color.ToUnityColor(),
+                        toPlayer: SteamPlayer,
+                        iconURL: iconUrl,
+                        useRichTextFormatting: isRich);
                 }
             }
 
             return PrintMessageTask().AsTask();
-        }
-
-        private IEnumerable<string> WrapLine(string line)
-        {
-            const int maxLength = 90;
-
-            using var currentLine = new ZStringBuilder(false);
-
-            foreach (var currentWord in line.Split(' '))
-            {
-                if (currentLine.Length > maxLength ||
-                    currentLine.Length + currentWord.Length > maxLength)
-                {
-                    yield return currentLine.ToString();
-                    currentLine.Clear();
-                }
-
-                if (currentLine.Length > 0)
-                {
-                    currentLine.Append(" ");
-                    currentLine.Append(currentWord);
-                }
-                else
-                {
-                    currentLine.Append(currentWord);
-                }
-            }
-
-            if (currentLine.Length > 0)
-            {
-                yield return currentLine.ToString();
-            }
         }
 
         public Task SetHungerAsync(double hunger)


### PR DESCRIPTION
Line wrapping at 90 characters is no longer necessary. The theoretical maximum number of characters a chat message can contain is 2048 as that's the default max string length in the network packet. The true limitation of message length shown is what can fit in two wrapped lines on the client-side, but this is independent of message length, as is shown below.

Message sent:
```
a.........b.........c.........d.........e.........f.........g.........h.........i.........j.........k.........l.........m.........n.........o.........p.........q.........r.........s.........t.........u.........v.........w.........x.........y.........z
```
Message shown:
![image](https://user-images.githubusercontent.com/16708907/178524681-9112c248-8f9e-48a1-be60-3ba06a8c10d7.png)
Characters used on client: 191

Message sent:
```
<color=blue>a.........<color=red>b.........<color=yellow>c.........<color=green>d.........<color=#111111>e.........<color=#212121>f.........<color=#911111>g.........<color=#119111>h.........i.........j.........k.........l.........m.........n.........o.........p.........q.........r.........s.........t.........u.........v.........w.........x.........y.........z
```
Message shown:
![image](https://user-images.githubusercontent.com/16708907/178524362-86948c90-3b6d-40b0-ae39-0baa152e7b66.png)
Characters used on client: 301