### PR TITLE
Fix being unable to generate migrations due to bad connection string

### DIFF
--- a/framework/OpenMod.EntityFrameworkCore.MySql/Configurator/MySqlDbContextConfigurator.cs
+++ b/framework/OpenMod.EntityFrameworkCore.MySql/Configurator/MySqlDbContextConfigurator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MySql.Data.MySqlClient;
 using OpenMod.EntityFrameworkCore.Configurator;
 using Pomelo.EntityFrameworkCore.MySql.Storage;
 
@@ -15,13 +16,23 @@ namespace OpenMod.EntityFrameworkCore.MySql.Configurator
             var connectionStringAccessor = dbContext.ServiceProvider.GetRequiredService<IConnectionStringAccessor>();
             var connectionString = connectionStringAccessor.GetConnectionString(connectionStringName);
 
-            var autoDetectedVersion = ServerVersion.AutoDetect(connectionString);
+
+            ServerVersion serverVersion;
+
+            try
+            {
+                serverVersion = ServerVersion.AutoDetect(connectionString);
+            }
+            catch (MySqlException)
+            {
+                serverVersion = ServerVersion.Default;
+            }
 
             optionsBuilder.UseMySql(connectionString!,
                 options =>
                 {
                     options.MigrationsHistoryTable(dbContext.MigrationsTableName);
-                    options.ServerVersion(autoDetectedVersion);
+                    options.ServerVersion(serverVersion);
                 });
         }
 


### PR DESCRIPTION
Unable to generate migrations in Visual Studio due to connection string in config.yaml being a template. This PR changes the code to use the default server version specified by Pomelo.EntityFrameworkCore.MySql in the case where a connection can not be established.