### PR TITLE
Add command parameter resolve providers for item and vehicle assets

### DIFF
--- a/unturned/OpenMod.Unturned/Items/UnturnedItemAssetCommandParameterResolveProvider.cs
+++ b/unturned/OpenMod.Unturned/Items/UnturnedItemAssetCommandParameterResolveProvider.cs
@@ -1,0 +1,63 @@
+﻿using OpenMod.API.Commands;
+using OpenMod.Extensions.Games.Abstractions.Items;
+using SDG.Unturned;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenMod.Unturned.Items
+{
+    public class UnturnedItemAssetCommandParameterResolveProvider : ICommandParameterResolveProvider
+    {
+        private readonly IItemDirectory m_ItemDirectory;
+
+        public UnturnedItemAssetCommandParameterResolveProvider(IItemDirectory itemDirectory)
+        {
+            m_ItemDirectory = itemDirectory;
+        }
+
+        public bool Supports(Type type)
+        {
+            return type == typeof(UnturnedItemAsset) || type == typeof(IItemAsset) || type == typeof(ItemAsset);
+        }
+
+        public async Task<object?> ResolveAsync(Type type, string input)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (!Supports(type))
+            {
+                throw new ArgumentException("The given type is not supported", nameof(type));
+            }
+
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            var itemAsset = await m_ItemDirectory.FindByIdAsync(input) ??
+                            await m_ItemDirectory.FindByNameAsync(input, false);
+
+            if (type == typeof(IItemAsset))
+            {
+                return itemAsset;
+            }
+
+            var unturnedItemAsset = itemAsset as UnturnedItemAsset;
+
+            if (type == typeof(UnturnedItemAsset))
+            {
+                return unturnedItemAsset;
+            }
+
+            if (type == typeof(ItemAsset))
+            {
+                return unturnedItemAsset?.ItemAsset;
+            }
+
+            throw new InvalidOperationException($"Unable to return type {type}");
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/ServiceConfigurator.cs
+++ b/unturned/OpenMod.Unturned/ServiceConfigurator.cs
@@ -14,6 +14,7 @@ using OpenMod.Extensions.Economy.Abstractions;
 using OpenMod.Extensions.Games.Abstractions;
 using OpenMod.Unturned.Commands;
 using OpenMod.Unturned.Configuration;
+using OpenMod.Unturned.Items;
 using OpenMod.Unturned.Locations;
 using OpenMod.Unturned.Permissions;
 using OpenMod.Unturned.Players;
@@ -22,8 +23,8 @@ using OpenMod.Unturned.RocketMod.Economy;
 using OpenMod.Unturned.RocketMod.Permissions;
 using OpenMod.Unturned.Steam;
 using OpenMod.Unturned.Users;
+using OpenMod.Unturned.Vehicles;
 using System;
-using System.Linq;
 
 namespace OpenMod.Unturned
 {
@@ -69,6 +70,8 @@ namespace OpenMod.Unturned
                 options.AddCommandParameterResolveProvider<UnturnedPlayerCommandParameterResolveProvider>();
                 options.AddCommandParameterResolveProvider<UnturnedLocationCommandParameterResolveProvider>();
                 options.AddCommandParameterResolveProvider<CSteamIDCommandParameterResolveProvider>();
+                options.AddCommandParameterResolveProvider<UnturnedItemAssetCommandParameterResolveProvider>();
+                options.AddCommandParameterResolveProvider<UnturnedVehicleAssetCommandParameterResolveProvider>();
             });
 
             if (RocketModIntegration.IsRocketModInstalled())

--- a/unturned/OpenMod.Unturned/Vehicles/UnturnedVehicleAssetCommandParameterResolveProvider.cs
+++ b/unturned/OpenMod.Unturned/Vehicles/UnturnedVehicleAssetCommandParameterResolveProvider.cs
@@ -1,0 +1,63 @@
+﻿using OpenMod.API.Commands;
+using OpenMod.Extensions.Games.Abstractions.Vehicles;
+using SDG.Unturned;
+using System;
+using System.Threading.Tasks;
+
+namespace OpenMod.Unturned.Vehicles
+{
+    public class UnturnedVehicleAssetCommandParameterResolveProvider : ICommandParameterResolveProvider
+    {
+        private readonly IVehicleDirectory m_VehicleDirectory;
+
+        public UnturnedVehicleAssetCommandParameterResolveProvider(IVehicleDirectory vehicleDirectory)
+        {
+            m_VehicleDirectory = vehicleDirectory;
+        }
+
+        public bool Supports(Type type)
+        {
+            return type == typeof(UnturnedVehicleAsset) || type == typeof(IVehicleAsset) || type == typeof(VehicleAsset);
+        }
+
+        public async Task<object?> ResolveAsync(Type type, string input)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (!Supports(type))
+            {
+                throw new ArgumentException("The given type is not supported", nameof(type));
+            }
+
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            var vehicleAsset = await m_VehicleDirectory.FindByIdAsync(input) ??
+                               await m_VehicleDirectory.FindByNameAsync(input, false);
+
+            if (type == typeof(IVehicleAsset))
+            {
+                return vehicleAsset;
+            }
+
+            var unturnedVehicleAsset = vehicleAsset as UnturnedVehicleAsset;
+
+            if (type == typeof(UnturnedVehicleAsset))
+            {
+                return unturnedVehicleAsset;
+            }
+
+            if (type == typeof(VehicleAsset))
+            {
+                return unturnedVehicleAsset?.VehicleAsset;
+            }
+
+            throw new InvalidOperationException($"Unable to return type {type}");
+        }
+    }
+}


### PR DESCRIPTION
Allows for code such as the following:
```
var itemAsset = Context.Parameters.GetAsync<UnturnedItemAsset>(0);
var vehicleAsset = Context.Parameters.GetAsync<UnturnedVehicleAsset>(1);
```