### PR TITLE
Last fixes for rcon

### DIFF
--- a/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconHost.cs
+++ b/framework/OpenMod.Core/Rcon/Tcp/BaseTcpRconHost.cs
@@ -80,26 +80,27 @@ namespace OpenMod.Core.Rcon.Tcp
                             }
 
                             var eventSubs = new List<IDisposable>();
-                            var sub = m_EventBus.Subscribe<RconClientAuthenticatingEvent>(m_Runtime, async (_, _, e) =>
-                            {
-                                if (e.Client != client)
+                            //there is no need to use this event since base tcp rcon already handle fail cases
+                                /*var sub = m_EventBus.Subscribe<RconClientAuthenticatingEvent>(m_Runtime, async (_, _, e) =>
                                 {
-                                    return;
-                                }
-
-                                // Ensure clients get disconnected if authentication failed
-                                if (!e.IsAuthenticated)
-                                {
-                                    if (client.IsConnected)
+                                    if (e.Client != client)
                                     {
-                                        await client.DisconnectAsync("Authorization failed.", cancellationToken);
+                                        return;
                                     }
-                                }
-                            });
 
-                            eventSubs.Add(sub);
+                                    // Ensure clients get disconnected if authentication failed
+                                    if (!e.IsAuthenticated)
+                                    {
+                                        if (client.IsConnected)
+                                        {
+                                            await client.DisconnectAsync("Authorization failed.", cancellationToken);
+                                        }
+                                    }
+                                });
 
-                            sub = m_EventBus.Subscribe<RconClientDisconnectedEvent>(m_Runtime, async (_, _, e) =>
+                                eventSubs.Add(sub);*/
+
+                            var sub = m_EventBus.Subscribe<RconClientDisconnectedEvent>(m_Runtime, async (_, _, e) =>
                             {
                                 if (e.Client != client)
                                 {

--- a/unturned/OpenMod.Unturned/RocketMod/Rcon/RocketModRconClient.cs
+++ b/unturned/OpenMod.Unturned/RocketMod/Rcon/RocketModRconClient.cs
@@ -47,6 +47,9 @@ namespace OpenMod.Unturned.RocketMod.Rcon
 
         protected override async Task OnDataReceivedAsync(ArraySegment<byte> data)
         {
+            m_Logger.LogDebug("Current buffer({BufferCount}): {Str}", m_Buffer.Count, BitConverter.ToString(m_Buffer.ToArray()));
+            m_Logger.LogDebug("Data receiived({DataCount}): {Str}", data.Count, BitConverter.ToString(data.ToArray()));
+
             for (var i = data.Offset; i < data.Count; i++)
             {
                 try

--- a/unturned/OpenMod.Unturned/RocketMod/Rcon/RocketModRconClient.cs
+++ b/unturned/OpenMod.Unturned/RocketMod/Rcon/RocketModRconClient.cs
@@ -63,7 +63,6 @@ namespace OpenMod.Unturned.RocketMod.Rcon
                             if (++i >= data.Count)
                             {
                                 m_NewLineType ??= NewLineType.Mac;
-                                m_Logger.LogInformation("MAC1");
                                 break;
                             }
 
@@ -71,18 +70,15 @@ namespace OpenMod.Unturned.RocketMod.Rcon
                             if (nextBt is not 0x0A)
                             {
                                 m_NewLineType ??= NewLineType.Mac;
-                                m_Logger.LogInformation("MAC2");
                                 i--;
                                 break;
                             }
 
                             m_NewLineType ??= NewLineType.Windows;
-                            m_Logger.LogInformation("Windows");
                             break;
 
                         case 0x0A:
                             m_NewLineType ??= NewLineType.Linux;
-                            m_Logger.LogInformation("Linux");
                             break;
 
                         default:


### PR DESCRIPTION
Rocketmod rcon:
* Remove debug use in test cases (spamming console with windows/linux/mac) when using rcon
* Adding properly debug when received data 

All rcon types:
* Prevent and fix disposal error for rcon when user fail login in first try (it automatically disconnects at first try instead of third one)