### PR TITLE
Add schemas for openmod.roles.yaml and openmod.users.yaml

### DIFF
--- a/framework/OpenMod.Core/Configuration/SchemaConstants.cs
+++ b/framework/OpenMod.Core/Configuration/SchemaConstants.cs
@@ -5,5 +5,7 @@ namespace OpenMod.Core.Configuration
         private const string c_SchemasDirectory = ".schemas";
 
         public const string c_RolesSchemaPath = c_SchemasDirectory + "/openmod.roles.yaml.schema.json";
+
+        public const string c_UsersSchemaPath = c_SchemasDirectory + "/openmod.users.yaml.schema.json";
     }
 }

--- a/framework/OpenMod.Core/Configuration/SchemaConstants.cs
+++ b/framework/OpenMod.Core/Configuration/SchemaConstants.cs
@@ -1,0 +1,9 @@
+namespace OpenMod.Core.Configuration
+{
+    internal static class SchemaConstants
+    {
+        private const string c_SchemasDirectory = ".schemas";
+
+        public const string c_RolesSchemaPath = c_SchemasDirectory + "/openmod.roles.yaml.schema.json";
+    }
+}

--- a/framework/OpenMod.Core/Permissions/PermissionRolesDataStore.cs
+++ b/framework/OpenMod.Core/Permissions/PermissionRolesDataStore.cs
@@ -12,6 +12,7 @@ using OpenMod.Core.Persistence;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using OpenMod.Core.Configuration;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -168,6 +169,17 @@ namespace OpenMod.Core.Permissions
 
         public virtual async Task SaveChangesAsync()
         {
+            if (m_DataStore is YamlDataStore yamlDataStore)
+            {
+                await yamlDataStore.SaveAsync(
+                    RolesKey,
+                    m_CachedPermissionRolesData,
+                    header: $"# yaml-language-server: $schema=./{SchemaConstants.c_RolesSchemaPath}\n"
+                );
+
+                return;
+            }
+
             await m_DataStore.SaveAsync(RolesKey, m_CachedPermissionRolesData);
         }
 

--- a/framework/OpenMod.Core/Permissions/PermissionRolesSchemaGenerator.cs
+++ b/framework/OpenMod.Core/Permissions/PermissionRolesSchemaGenerator.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Autofac;
+using Newtonsoft.Json;
+using OpenMod.API;
+using OpenMod.API.Eventing;
+using OpenMod.Core.Configuration;
+using OpenMod.Core.Events;
+using OpenMod.Core.Helpers;
+
+namespace OpenMod.Core.Permissions
+{
+    internal class PermissionRolesSchemaGenerator : IEventListener<OpenModInitializedEvent>
+    {
+        private readonly IServiceProvider m_ServiceProvider;
+
+        public PermissionRolesSchemaGenerator(IOpenModHost openModHost)
+        {
+            m_ServiceProvider = openModHost.LifetimeScope.Resolve<IServiceProvider>();
+        }
+
+        public Task HandleEventAsync(object? sender, OpenModInitializedEvent @event)
+        {
+            var rolesSchemaFile = Path.Combine(@event.Host.WorkingDirectory, SchemaConstants.c_RolesSchemaPath);
+
+            AsyncHelper.Schedule(
+                "Writing " + SchemaConstants.c_RolesSchemaPath,
+                async () => await WriteSchemaAsync(rolesSchemaFile)
+            );
+
+            return Task.CompletedTask;
+        }
+
+        private async Task WriteSchemaAsync(string path)
+        {
+            var permissions = await PermissionsUtils.GetAllPossiblePermissionsAsync(m_ServiceProvider);
+            var permissionJson = JsonConvert.SerializeObject(permissions);
+            var schema = c_SchemaTemplate.Replace(c_PermissionsPlaceholder, permissionJson);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, schema);
+        }
+
+        private const string c_PermissionsPlaceholder = "<<PERMISSIONS_PLACEHOLDER>>";
+
+        private const string c_SchemaTemplate = @"
+{
+    ""$schema"": ""http://json-schema.org/draft-06/schema#"",
+    ""$ref"": ""#/definitions/RootObject"",
+    ""definitions"": {
+        ""RootObject"": {
+            ""type"": ""object"",
+            ""additionalProperties"": false,
+            ""properties"": {
+                ""roles"": {
+                    ""type"": ""array"",
+                    ""items"": {
+                        ""$ref"": ""#/definitions/Role""
+                    }
+                }
+            },
+            ""required"": [
+                ""roles""
+            ],
+            ""title"": ""Roles Configuration""
+        },
+        ""Role"": {
+            ""type"": ""object"",
+            ""additionalProperties"": false,
+            ""properties"": {
+                ""id"": {
+                    ""type"": ""string"",
+                    ""description"": ""The unique identifier of the role.""
+                },
+                ""priority"": {
+                    ""type"": ""integer"",
+                    ""description"": ""In case of conflicting permissions, this attribute will define which role gets preferred.""
+                },
+                ""parents"": {
+                    ""type"": ""array"",
+                    ""uniqueItems"": true,
+                    ""items"": {
+                        ""type"": ""string""
+                    },
+                    ""description"": ""The parent roles, whose permissions are inherited.""
+                },
+                ""permissions"": {
+                    ""type"": ""array"",
+                    ""uniqueItems"": true,
+                    ""items"": {
+                        ""type"": ""string"",
+                        ""enum"": " + c_PermissionsPlaceholder + @"
+                    },
+                    ""description"": ""List of permissions the role has.""
+                },
+                ""displayName"": {
+                    ""type"": ""string"",
+                    ""description"": ""Human-readable name of the role.""
+                },
+                ""data"": {
+                    ""type"": ""object"",
+                    ""title"": ""Data"",
+                    ""description"": ""Data that can be attached to the role by plugins.""
+                },
+                ""isAutoAssigned"": {
+                    ""type"": ""boolean"",
+                    ""description"": ""Automatically assigns the role to new users. Does not assign to existing users.""
+                }
+            },
+            ""required"": [
+                ""id"",
+                ""isAutoAssigned"",
+                ""priority""
+            ],
+            ""title"": ""Role""
+        }
+    }
+}
+";
+    }
+}

--- a/framework/OpenMod.Core/Permissions/PermissionsUtils.cs
+++ b/framework/OpenMod.Core/Permissions/PermissionsUtils.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MoreLinq;
+using OpenMod.API;
+using OpenMod.API.Commands;
+using OpenMod.API.Permissions;
+using OpenMod.API.Plugins;
+
+namespace OpenMod.Core.Permissions
+{
+    internal static class PermissionsUtils
+    {
+        public static async Task<ISet<string>> GetAllPossiblePermissionsAsync(IServiceProvider serviceProvider)
+        {
+            var permissionRegistry = serviceProvider.GetRequiredService<IPermissionRegistry>();
+            var openModHost = serviceProvider.GetRequiredService<IOpenModHost>();
+            var pluginActivator = serviceProvider.GetRequiredService<IPluginActivator>();
+            var commandStore = serviceProvider.GetRequiredService<ICommandStore>();
+            var commandPermissionBuilder = serviceProvider.GetRequiredService<ICommandPermissionBuilder>();
+
+            var openModComponents = new IOpenModComponent[] { openModHost }
+                .Concat(pluginActivator.ActivatedPlugins)
+                .ToArray();
+
+            var permissionsOfAllCommands = await GetPermissionsOfAllCommandsAsync(commandStore, commandPermissionBuilder);
+            var permissionsOfAllComponents = GetPermissionsOfAllComponents(permissionRegistry, openModComponents);
+
+            var allPermissions = permissionsOfAllComponents
+                .Union(permissionsOfAllCommands)
+                .ToArray();
+
+            return allPermissions
+                .Union(allPermissions.Select(p => '!' + p))
+                .ToHashSet();
+        }
+
+        private static async Task<ISet<string>> GetPermissionsOfAllCommandsAsync(
+            ICommandStore commandStore,
+            ICommandPermissionBuilder commandPermissionBuilder)
+        {
+            var commands = await commandStore.GetCommandsAsync();
+
+            return commands
+                .SelectMany(c =>
+                {
+                    var permission = commandPermissionBuilder.GetPermission(c, commands);
+
+                    var permissionRegistrations = c.PermissionRegistrations?
+                        .Select(r => permission + '.' + r.Permission) ?? Enumerable.Empty<string>();
+
+                    // ReSharper disable once InvokeAsExtensionMethod
+                    return MoreEnumerable.Append(permissionRegistrations, permission);
+                })
+                .SelectMany(DefaultPermissionCheckProvider.BuildPermissionTree)
+                .ToHashSet();
+        }
+
+        private static ISet<string> GetPermissionsOfAllComponents(
+            IPermissionRegistry permissionRegistry,
+            IReadOnlyCollection<IOpenModComponent> openModComponents)
+        {
+            return openModComponents
+                .SelectMany(c => permissionRegistry
+                    .GetPermissions(c)
+                    .Select(r => c.OpenModComponentId + '.' + r.Permission))
+                .SelectMany(DefaultPermissionCheckProvider.BuildPermissionTree)
+                .ToHashSet();
+        }
+    }
+}

--- a/framework/OpenMod.Core/Persistence/YamlDataStore.cs
+++ b/framework/OpenMod.Core/Persistence/YamlDataStore.cs
@@ -153,7 +153,12 @@ namespace OpenMod.Core.Persistence
             }
         }
 
-        public virtual Task SaveAsync<T>(string key, T? data) where T : class
+        public virtual async Task SaveAsync<T>(string key, T? data) where T : class
+        {
+            await SaveAsync(key, data, "");
+        }
+
+        internal Task SaveAsync<T>(string key, T? data, string header) where T : class
         {
             CheckKeyValid(key);
 
@@ -161,6 +166,11 @@ namespace OpenMod.Core.Persistence
                 data == null
                     ? string.Empty
                     : m_Serializer.Serialize(data);
+
+            if (header != "")
+            {
+                serializedYaml = header + serializedYaml;
+            }
 
             var encodedData = Encoding.UTF8.GetBytes(serializedYaml);
             var filePath = GetFilePathForKey(key);
@@ -351,7 +361,8 @@ namespace OpenMod.Core.Persistence
 
             if (!key.All(d => char.IsLetterOrDigit(d) || d == '.'))
             {
-                throw new Exception($"Invalid data store key: {key}. Key can only consist of alphanumeric characters and dot");
+                throw new Exception(
+                    $"Invalid data store key: {key}. Key can only consist of alphanumeric characters and dot");
             }
         }
 

--- a/framework/OpenMod.Core/ServiceConfigurator.cs
+++ b/framework/OpenMod.Core/ServiceConfigurator.cs
@@ -55,6 +55,8 @@ namespace OpenMod.Core
             serviceCollection.AddTransient<IStringLocalizerFactory, ConfigurationBasedStringLocalizerFactory>();
             serviceCollection.AddTransient(typeof(IPluginAccessor<>), typeof(PluginAccessor<>));
             serviceCollection.AddSingleton<IAutoCompleteHandler, CommandAutoCompleteHandler>();
+
+            serviceCollection.AddHostedService<UsersSchemaGenerator>();
         }
     }
 }

--- a/framework/OpenMod.Core/Users/UsersSchemaGenerator.cs
+++ b/framework/OpenMod.Core/Users/UsersSchemaGenerator.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
+using OpenMod.API;
+using OpenMod.API.Permissions;
+using OpenMod.API.Persistence;
+using OpenMod.Core.Configuration;
+using OpenMod.Core.Helpers;
+using OpenMod.Core.Permissions;
+using OpenMod.Core.Persistence;
+
+namespace OpenMod.Core.Users
+{
+    internal class UsersSchemaGenerator : BackgroundService
+    {
+        private readonly IOpenModHost m_OpenModHost;
+        private readonly IPermissionRoleStore m_PermissionRoleStore;
+        private readonly IDataStore m_DataStore;
+        private readonly IServiceProvider m_ServiceProvider;
+
+        public UsersSchemaGenerator(
+            IOpenModHost openModHost,
+            IPermissionRoleStore permissionRoleStore,
+            IOpenModDataStoreAccessor dataStoreAccessor)
+        {
+            m_OpenModHost = openModHost;
+            m_PermissionRoleStore = permissionRoleStore;
+            m_DataStore = dataStoreAccessor.DataStore;
+            m_ServiceProvider = openModHost.LifetimeScope.Resolve<IServiceProvider>();
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (m_DataStore is not YamlDataStore)
+            {
+                return Task.CompletedTask;
+            }
+
+            ScheduleSchemaReload();
+
+            m_DataStore.AddChangeWatcher("roles", m_OpenModHost, ScheduleSchemaReload);
+
+            return Task.CompletedTask;
+        }
+
+        private void ScheduleSchemaReload()
+        {
+            var rolesSchemaFile = Path.Combine(m_OpenModHost.WorkingDirectory, SchemaConstants.c_UsersSchemaPath);
+
+            AsyncHelper.Schedule(
+                "Writing " + SchemaConstants.c_UsersSchemaPath,
+                async () => await WriteSchemaAsync(rolesSchemaFile)
+            );
+        }
+
+        private async Task WriteSchemaAsync(string path)
+        {
+            var permissions = await PermissionsUtils.GetAllPossiblePermissionsAsync(m_ServiceProvider);
+            var permissionsJson = JsonConvert.SerializeObject(permissions);
+
+            var roles = (await m_PermissionRoleStore.GetRolesAsync()).Select(r => r.Id);
+            var rolesJson = JsonConvert.SerializeObject(roles);
+
+            var sb = new StringBuilder(c_SchemaTemplate);
+            sb.Replace(c_PermissionsPlaceholder, permissionsJson);
+            sb.Replace(c_RolesPlaceholder, rolesJson);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        private const string c_PermissionsPlaceholder = "<<PERMISSIONS_PLACEHOLDER>>";
+        private const string c_RolesPlaceholder = "<<ROLES_PLACEHOLDER>>";
+
+        private const string c_SchemaTemplate = @"
+{
+    ""$schema"": ""http://json-schema.org/draft-06/schema#"",
+    ""$ref"": ""#/definitions/RootObject"",
+    ""definitions"": {
+        ""RootObject"": {
+            ""type"": ""object"",
+            ""additionalProperties"": false,
+            ""properties"": {
+                ""users"": {
+                    ""type"": ""array"",
+                    ""items"": {
+                        ""$ref"": ""#/definitions/User""
+                    }
+                }
+            },
+            ""required"": [
+                ""users""
+            ],
+            ""title"": ""Users Configuration""
+        },
+        ""User"": {
+            ""type"": ""object"",
+            ""additionalProperties"": false,
+            ""properties"": {
+                ""id"": {
+                    ""type"": ""string"",
+                    ""description"": ""The unique identifier of the user.""
+                },
+                ""type"": {
+                    ""type"": ""string""
+                },
+                ""lastDisplayName"": {
+                    ""type"": ""string""
+                },
+                ""firstSeen"": {
+                    ""type"": [""string"", ""null""],
+                    ""description"": ""The first time the user has been seen""
+                },
+                ""lastSeen"": {
+                    ""type"": [""string"", ""null""],
+                    ""description"": ""The last time the user has been seen""
+                },
+                ""banInfo"": {
+                    ""type"": [""object"", ""null""],
+                    ""additionalProperties"": false,
+                    ""properties"": {
+                        ""expireDate"": {
+                            ""type"": ""string""
+                        },
+                        ""instigatorType"": {
+                            ""type"": ""string""
+                        },
+                        ""instigatorId"": {
+                            ""type"": ""string""
+                        },
+                        ""reason"": {
+                            ""type"": ""string""
+                        }
+                    },
+                    ""title"": ""Ban Info""
+                },
+                ""permissions"": {
+                    ""type"": ""array"",
+                    ""uniqueItems"": true,
+                    ""items"": {
+                        ""type"": ""string"",
+                        ""enum"": " + c_PermissionsPlaceholder + @"
+                    }
+                },
+                ""roles"": {
+                    ""type"": ""array"",
+                    ""uniqueItems"": true,
+                    ""items"": {
+                        ""type"": ""string"",
+                        ""enum"": " + c_RolesPlaceholder + @"
+                    }
+                },
+                ""data"": {
+                    ""type"": ""object"",
+                    ""title"": ""User Data""
+                }
+            },
+            ""required"": [
+                ""id"",
+                ""type""
+            ],
+            ""title"": ""User""
+        }
+    }
+}
+";
+    }
+}


### PR DESCRIPTION
Adds description, auto completion and validation of roles, permissions and other properties in `openmod.roles.yaml` and `openmod.users.yaml` file.

## Features

- Supports auto completion of original, negated and wildcard permissions

  ![image](https://user-images.githubusercontent.com/37713088/193470125-fb6beefb-8cd7-4bcb-b5b3-d96ced9be0be.png)

- Also works with roles

  ![image](https://user-images.githubusercontent.com/37713088/193469554-98a536a8-1459-4df6-8e02-959441852c63.png)

- Shows an error if the value is unknown / not valid

  ![image](https://user-images.githubusercontent.com/37713088/193468291-984af7b1-46cd-490d-8013-3df6fa7a0599.png)

- Shows an error if a required property is missing

  ![image](https://user-images.githubusercontent.com/37713088/193468461-b37da0f5-c376-495f-ad97-1e4514e74c2b.png)

- Shows an error if a property is unknown

  ![image](https://user-images.githubusercontent.com/37713088/193469655-7db1fe40-ca9d-4cfa-aaad-2bcac01dd2c5.png)

- Some properties have description

  ![image](https://user-images.githubusercontent.com/37713088/193469508-57a50686-1e8c-47cd-9855-dc1f94ea0b05.png)


## Required editor extensions

VS Code: `YAML`
Sublime Text: both `LSP` and `LSP-yaml`
Others: not tested, but need those which have support of `yaml-language-server`

## Things to know

- It is also compatible with json (in case OpenMod will use it in future).
- Schema files are saved in `.schemas` folder, which is hidden by default in the explorer.
- Schema files are generated on startup, or every time related data changes (e.g. when file is edited).
- Issue: text editor need to be restarted every time schema changes.
- Needs testing - only tested on OpenMod.Standalone without plugins.