### PR TITLE
Feature/bed claim event

### DIFF
--- a/unturned/OpenMod.Unturned/Building/Events/UnturnedBarricadeDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Building/Events/UnturnedBarricadeDamagingEvent.cs
@@ -1,6 +1,5 @@
 ﻿using OpenMod.Unturned.Players;
 using SDG.Unturned;
-using Steamworks;
 
 namespace OpenMod.Unturned.Building.Events
 {

--- a/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
@@ -29,14 +29,19 @@ namespace OpenMod.Unturned.Players.Interacting.Events
 
         private void Events_OnBedBedClaiming(InteractableBed bed, CSteamID steamid, ref bool cancel)
         {
-            var player = GetUnturnedPlayer(steamid)!;
-            var @event = new UnturnedPlayerBedClaimingEvent(bed, player)
+            var player = GetUnturnedPlayer(steamid);
+            // Very important to make sure the player's not null because it has a delay on the server when the player unclaiming the bed
+            // and it causes a null reference exception
+            if (player != null)
             {
-                IsCancelled = !cancel
-            };
+                var @event = new UnturnedPlayerBedClaimingEvent(bed, player)
+                {
+                    IsCancelled = !cancel
+                };
 
-            Emit(@event);
-            cancel = !@event.IsCancelled;
+                Emit(@event);
+                cancel = !@event.IsCancelled;
+            }
         }
 
         private delegate void BedClaiming(InteractableBed bed, CSteamID steamID, ref bool cancel);

--- a/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
@@ -1,0 +1,69 @@
+extern alias JetBrainsAnnotations;
+using System;
+using System.Reflection;
+using HarmonyLib;
+using JetBrainsAnnotations::JetBrains.Annotations;
+using OpenMod.Unturned.Events;
+using OpenMod.Unturned.Patching;
+using SDG.Unturned;
+using Steamworks;
+
+namespace OpenMod.Unturned.Players.Interacting.Events
+{
+    [UsedImplicitly]
+    internal class UnturnedInteractEventsListener : UnturnedEventsListener
+    {
+        public UnturnedInteractEventsListener(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        public override void Subscribe()
+        {
+            OnBedClaiming += Events_OnBedBedClaiming;
+        }
+
+        public override void Unsubscribe()
+        {
+            OnBedClaiming -= Events_OnBedBedClaiming;
+        }
+
+        private void Events_OnBedBedClaiming(InteractableBed bed, CSteamID steamid, ref bool cancel)
+        {
+            var player = GetUnturnedPlayer(steamid)!;
+            var @event = new UnturnedPlayerBedClaimingEvent(bed, player)
+            {
+                IsCancelled = !cancel
+            };
+
+            Emit(@event);
+            cancel = !@event.IsCancelled;
+        }
+
+        private delegate void BedClaiming(InteractableBed bed, CSteamID steamID, ref bool cancel);
+        private static event BedClaiming? OnBedClaiming;
+
+        [UsedImplicitly]
+        [HarmonyPatch]
+        internal static class Patches
+        {
+            [HarmonyCleanup]
+            public static Exception? Cleanup(Exception ex, MethodBase original)
+            {
+                HarmonyExceptionHandler.ReportCleanupException(typeof(Patches), ex, original);
+                return null;
+            }
+
+            [UsedImplicitly]
+            [HarmonyPatch(typeof(InteractableBed), "ServerSetBedOwnerInternal")]
+            [HarmonyPrefix]
+            public static bool ServerSetBedOwnerInternal(InteractableBed bed, byte x, byte y, ushort plant, BarricadeRegion region, CSteamID steamID)
+            {
+                var cancel = false;
+
+                OnBedClaiming?.Invoke(bed, steamID, ref cancel);
+
+                return !cancel;
+            }
+        }
+    }
+}

--- a/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedPlayerBedClaimingEvent.cs
+++ b/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedPlayerBedClaimingEvent.cs
@@ -1,0 +1,17 @@
+using OpenMod.API.Eventing;
+using OpenMod.Unturned.Events;
+using SDG.Unturned;
+
+namespace OpenMod.Unturned.Players.Interacting.Events
+{
+    public class UnturnedPlayerBedClaimingEvent : UnturnedPlayerEvent, ICancellableEvent
+    {
+        public UnturnedPlayerBedClaimingEvent(InteractableBed bed, UnturnedPlayer player) : base(player)
+        {
+            Bed = bed;
+        }
+
+        public InteractableBed Bed { get; }
+        public bool IsCancelled { get; set; }
+    }
+}


### PR DESCRIPTION
Because of the direct instance to the `InteractableBed` it may look strange and weird, I think, a layer of abstractions on it can be added