### PR TITLE
Fix invalid patch of bed claiming

### DIFF
--- a/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Interacting/Events/UnturnedInteractEventsListener.cs
@@ -59,9 +59,9 @@ namespace OpenMod.Unturned.Players.Interacting.Events
             }
 
             [UsedImplicitly]
-            [HarmonyPatch(typeof(InteractableBed), "ServerSetBedOwnerInternal")]
+            [HarmonyPatch(typeof(BarricadeManager), "ServerSetBedOwnerInternal")]
             [HarmonyPrefix]
-            public static bool ServerSetBedOwnerInternal(InteractableBed bed, byte x, byte y, ushort plant, BarricadeRegion region, CSteamID steamID)
+            public static bool ServerSetBedOwnerInternal(InteractableBed bed, CSteamID steamID)
             {
                 var cancel = false;
 


### PR DESCRIPTION
Fixes exception on patch:
```ini
[23:01:35 ERR][OpenMod.Harmony] Failed to patch original method null from patching type OpenMod.Unturned.Players.Interacting.Events.Patches
System.ArgumentException: Undefined target method for patch method static System.Boolean OpenMod.Unturned.Players.Interacting.Events.Patches::ServerSetBedOwnerInternal(SDG.Unturned.InteractableBed bed, System.Byte x, System.Byte y, System.UInt16 plant, SDG.Unturned.BarricadeRegion region, Steamworks.CSteamID steamID)
  at HarmonyLib.PatchClassProcessor.PatchWithAttributes (System.Reflection.MethodBase& lastOriginal) [0x00047] in <2414a8eb44e8496080270436f777e942>:0
  at HarmonyLib.PatchClassProcessor.Patch () [0x0006a] in <2414a8eb44e8496080270436f777e942>:0
  ```