### PR TITLE
Fix some loggers doesn't work on startup 

### DIFF
--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -416,12 +416,10 @@ namespace OpenMod.Runtime
 
         private void SetupSerilog(LoggerConfiguration? loggerConfiguration = null)
         {
-#if DEBUG
             Serilog.Debugging.SelfLog.Enable(s =>
             {
                 Console.WriteLine(s);
             });
-#endif
 
             Log.CloseAndFlush();
             loggerConfiguration ??= new LoggerConfiguration();


### PR DESCRIPTION
Fixes that throwing exception in `IServiceConfigurator.ConfigureServices` doesn't log anything.



Also, enables `SelfLog` on release builds to get runtime errors, for example sink `Serilog.Sinks.MariaDB` logs 
```
2023-04-08T11:37:11.7531756Z Unable to write 5 log events to the database due to following error: Table 'openmod.logs' doesn't exist
```
So user should create table or add argument to automatically create table.