### PR TITLE
fix: update `dotnet -i` to `dotnet install` #705

### DIFF
--- a/docs/devdoc/guides/getting-started.md
+++ b/docs/devdoc/guides/getting-started.md
@@ -36,7 +36,7 @@ cd C:\Users\<Username>\source\repos\MyPlugin\
 
 After that, install the OpenMod Plugin Templates for the .NET Core SDK:
 ```
-dotnet new -i "OpenMod.Templates::*"
+dotnet new install OpenMod.Templates::*
 ```
 
 Finally, you can generate the plugin project with this command:  


### PR DESCRIPTION
`dotnet -i` is no longer in use as stated in the screenshot in #705, also removed the "" from OpenMod.Templates::*