### PR TITLE
Fix MethodAccessException when configuring EF Core DB context

### DIFF
--- a/framework/OpenMod.EntityFrameworkCore.MySql/Extensions/MySqlContainerBuilderExtensions.cs
+++ b/framework/OpenMod.EntityFrameworkCore.MySql/Extensions/MySqlContainerBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace OpenMod.EntityFrameworkCore.MySql.Extensions
             return AddMySqlDbContextInternal(containerBuilder, dbContextType, optionsBuilder, serviceLifetime);
         }
 
-        internal static ContainerBuilder AddMySqlDbContextInternal(this ContainerBuilder containerBuilder,
+        private static ContainerBuilder AddMySqlDbContextInternal(this ContainerBuilder containerBuilder,
             Type dbContextType,
             Action<DbContextOptionsBuilder>? optionsBuilder,
             ServiceLifetime? serviceLifetime)
@@ -65,7 +65,7 @@ namespace OpenMod.EntityFrameworkCore.MySql.Extensions
                 .SingleInstance()
                 .AutoActivate();
 
-            containerBuilder.AddDbContextInternal(dbContextType, optionsBuilder,
+            containerBuilder.AddDbContext(dbContextType, optionsBuilder,
                 serviceLifetime ?? ServiceLifetime.Transient, new MySqlDbContextConfigurator());
 
             return containerBuilder;

--- a/framework/OpenMod.EntityFrameworkCore/Extensions/EntityFrameworkCoreContainerBuilderExtensions.cs
+++ b/framework/OpenMod.EntityFrameworkCore/Extensions/EntityFrameworkCoreContainerBuilderExtensions.cs
@@ -55,7 +55,7 @@ namespace OpenMod.EntityFrameworkCore.Extensions
             return AddDbContextInternal(containerBuilder, dbContextType, optionsBuilder, serviceLifetime, configurator);
         }
 
-        internal static ContainerBuilder AddDbContextInternal(this ContainerBuilder containerBuilder,
+        private static ContainerBuilder AddDbContextInternal(this ContainerBuilder containerBuilder,
             Type dbContextType,
             Action<DbContextOptionsBuilder>? optionsBuilderAction,
             ServiceLifetime? serviceLifetime,


### PR DESCRIPTION
Fixes the exception that throws on non-Mono runtimes

```
[10:45:49 INF][OpenMod.Runtime.OpenModHostedService] Initializing for host: Openmod Standalone v0.0.0+b482449e2623fe726bac734274e1dcd532c259d3
[10:45:49 INF][OpenMod.Runtime.OpenModHostedService] Loading plugins...
[10:45:49 ERR][OpenMod.Core.Plugins.PluginActivator] Failed to load plugin from type: Shops.ShopsPlugin in assembly: Shops-91f958, Version=2.0.5.0, Culture=neutral, PublicKeyToken=null
System.MethodAccessException: Attempt by method 'OpenMod.EntityFrameworkCore.MySql.Extensions.MySqlContainerBuilderExtensions.AddMySqlDbContextInternal(Autofac.ContainerBuilder, System.Type, System.Action`1<Microsoft.EntityFrameworkCore.DbContextOptionsBuilder>, System.Nullable`1<Microsoft.Extensions.DependencyInjection.ServiceLifetime>)' to access method 'OpenMod.EntityFrameworkCore.Extensions.EntityFrameworkCoreContainerBuilderExtensions.AddDbContextInternal(Autofac.ContainerBuilder, System.Type, System.Action`1<Microsoft.EntityFrameworkCore.DbContextOptionsBuilder>, System.Nullable`1<Microsoft.Extensions.DependencyInjection.ServiceLifetime>, OpenMod.EntityFrameworkCore.Configurator.IDbContextConfigurator)' failed.
   at OpenMod.EntityFrameworkCore.MySql.Extensions.MySqlContainerBuilderExtensions.AddMySqlDbContextInternal(ContainerBuilder containerBuilder, Type dbContextType, Action`1 optionsBuilder, Nullable`1 serviceLifetime)
   at OpenMod.EntityFrameworkCore.MySql.Extensions.MySqlContainerBuilderExtensions.AddMySqlDbContext[T](ContainerBuilder containerBuilder)
   at OpenMod.Core.Plugins.PluginActivator.<>c__DisplayClass11_1.<TryActivatePluginAsync>b__0(ContainerBuilder containerBuilder)
   at Autofac.Core.Lifetime.LifetimeScope.CreateScopeRestrictedRegistry(Object tag, Action`1 configurationAction)
   at Autofac.Core.Lifetime.LifetimeScope.BeginLifetimeScope(Object tag, Action`1 configurationAction)
   at OpenMod.Core.Ioc.LifetimeScopeExtensions.BeginLifetimeScopeEx(ILifetimeScope this, Action`1 configurationAction)
   at OpenMod.Core.Plugins.PluginActivator.<TryActivatePluginAsync>d__11.MoveNext()
```
