### PR TITLE
Disable auto hard reload on upgrade command

### DIFF
--- a/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
+++ b/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
@@ -116,7 +116,10 @@ namespace OpenMod.Unturned.Commands
                 return;
             }
 
-            if (Hotloader.Enabled)
+            await PrintAsync("Update has been installed. Restart to apply it.");
+
+            // fix hard-reload to support reloading after upgrading
+            /*if (Hotloader.Enabled)
             {
                 var modulePath = Path.Combine(openModDirPath, "OpenMod.Unturned.Module.dll");
                 var moduleAssembly = Hotloader.LoadAssembly(File.ReadAllBytes(modulePath));
@@ -156,7 +159,7 @@ namespace OpenMod.Unturned.Commands
             else
             {
                 await PrintAsync("Update has been installed. Restart to apply it.");
-            }
+            }*/
         }
 
         private void DeleteBackup(string openModDirPath)


### PR DESCRIPTION
By default, job scheduler will try to upgrade OpenMod on Sunday and if it's found update, then it does the hard reload.
For some reason, it's very unstable, so for better stability we just print the message to restart the server to apply changes.
