### PR TITLE
Use AsmResolver for hotloading

### DIFF
--- a/framework/OpenMod.Common/Helpers/AssemblyNameEqualityComparer.cs
+++ b/framework/OpenMod.Common/Helpers/AssemblyNameEqualityComparer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace OpenMod.Common.Helpers;
+
+/// <summary>
+/// Comparer of <see cref="AssemblyName"/> that comparers the name
+/// </summary>
+public sealed class AssemblyNameEqualityComparer : IEqualityComparer<AssemblyName>
+{
+    public static AssemblyNameEqualityComparer Instance { get; } = new();
+
+    private AssemblyNameEqualityComparer() { }
+
+    public bool Equals(AssemblyName x, AssemblyName y)
+    {
+        if (x == y)
+        {
+            return true;
+        }
+
+        if (x == null || y == null)
+        {
+            return false;
+        }
+
+        return x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public int GetHashCode(AssemblyName obj)
+    {
+        return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name);
+    }
+}

--- a/framework/OpenMod.Common/Hotloading/Hotloader.cs
+++ b/framework/OpenMod.Common/Hotloading/Hotloader.cs
@@ -1,10 +1,18 @@
-﻿using dnlib.DotNet;
+﻿using AsmResolver;
+using AsmResolver.IO;
+using AsmResolver.PE;
+using AsmResolver.PE.DotNet;
+using AsmResolver.PE.DotNet.Builder;
+using AsmResolver.PE.DotNet.Metadata.Strings;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using OpenMod.Common.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace OpenMod.Common.Hotloading
 {
@@ -14,7 +22,8 @@ namespace OpenMod.Common.Hotloading
     /// </summary>
     public static class Hotloader
     {
-        private static readonly Dictionary<string, Assembly> s_Assemblies;
+        private static readonly Dictionary<AssemblyName, Assembly> s_Assemblies;
+        private static readonly bool s_IsMono;
 
         /// <summary>
         /// Defines if hotloading is enabled.
@@ -23,13 +32,14 @@ namespace OpenMod.Common.Hotloading
 
         static Hotloader()
         {
-            s_Assemblies = new Dictionary<string, Assembly>();
+            s_Assemblies = new(AssemblyNameEqualityComparer.Instance);
+            s_IsMono = Type.GetType("Mono.Runtime") is not null;
             AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
         }
 
         private static Assembly? OnAssemblyResolve(object sender, ResolveEventArgs args)
         {
-            return GetAssembly(args.Name);
+            return FindAssembly(new(args.Name));
         }
 
         /// <summary>
@@ -55,42 +65,65 @@ namespace OpenMod.Common.Hotloading
                 return Assembly.Load(assemblyData, assemblySymbols);
             }
 
-            using var input = new MemoryStream(assemblyData, writable: false);
-            using var output = new MemoryStream();
+            var image = PEImage.FromBytes(assemblyData);
+            var isStrongNamed = (image.DotNetDirectory!.Flags & DotNetDirectoryFlags.StrongNameSigned) == DotNetDirectoryFlags.StrongNameSigned;
 
-            var modCtx = ModuleDef.CreateModuleContext();
-            var module = ModuleDefMD.Load(input, modCtx);
-
-            var isMono = Type.GetType("Mono.Runtime") != null;
-            var isStrongNamed = module.Assembly.PublicKey != null;
-
-            if (!isMono && isStrongNamed)
+            if (!s_IsMono && isStrongNamed)
             {
                 // Don't hotload strong-named assemblies unless mono
                 // Will cause FileLoadException's if not mono
                 return Assembly.Load(assemblyData, assemblySymbols);
             }
 
-            var realFullname = module.Assembly.FullName;
+            var metadata = image.DotNetDirectory.Metadata!;
+            var tablesStream = metadata.GetStream<TablesStream>();
+            var oldStringsStream = metadata.GetStream<StringsStream>();
 
-            if (s_Assemblies.ContainsKey(realFullname))
-            {
-                s_Assemblies.Remove(realFullname);
-            }
+            // get reference to assembly def row
+            ref var assemblyRow = ref tablesStream
+                .GetTable<AssemblyDefinitionRow>(TableIndex.Assembly)
+                .GetRowRef(1);
 
-            var guid = Guid.NewGuid().ToString().Replace("-", "").Substring(0, 6);
-            var name = $"{module.Assembly.Name}-{guid}";
+            // get original name
+            string name = oldStringsStream.GetStringByIndex(assemblyRow.Name)!;
 
-            module.Assembly.Name = name;
-            module.Assembly.PublicKey = null;
-            module.Assembly.HasPublicKey = false;
+            // structure full name
+            var version = new Version(assemblyRow.MajorVersion, assemblyRow.MinorVersion, assemblyRow.BuildNumber, assemblyRow.RevisionNumber);
+            var realFullName = $"{name}, Version={version}, Culture=neutral, PublicKeyToken=null";
+            var realAssemblyName = new AssemblyName(realFullName);
 
-            module.Write(output);
-            output.Seek(offset: 0, SeekOrigin.Begin);
+            // generate new name
+            var guid = Guid.NewGuid().ToString("N").Substring(0, 6);
+            var newName = $"{name}-{guid}";
+
+            // update assembly def name
+            assemblyRow.Name = oldStringsStream.GetPhysicalSize();
+            using var output = new MemoryStream();
+
+            var writer = new BinaryStreamWriter(output);
+
+            writer.WriteBytes(oldStringsStream.CreateReader().ReadToEnd());
+            writer.WriteBytes(Encoding.UTF8.GetBytes(newName));
+            writer.WriteByte(0); // Add Null Terminator
+            writer.Align(4);
+
+            var newStringsStream = new SerializedStringsStream(output.ToArray());
+            // strings index size may have changed, updating in tables stream
+            tablesStream.StringIndexSize = newStringsStream.IndexSize;
+
+            // replace old strings with new one
+            metadata.Streams[metadata.Streams.IndexOf(oldStringsStream)] = newStringsStream;
+
+            var builder = new ManagedPEFileBuilder();
+            // reuse old output stream
+            output.SetLength(0);
+
+            builder.CreateFile(image).Write(output);
 
             var newAssemblyData = output.ToArray();
+
             var assembly = Assembly.Load(newAssemblyData, assemblySymbols);
-            s_Assemblies.Add(realFullname, assembly);
+            s_Assemblies[realAssemblyName] = assembly;
             return assembly;
         }
 
@@ -111,21 +144,22 @@ namespace OpenMod.Common.Hotloading
         /// </summary>
         /// <param name="fullname">The assembly name to resolve.</param>
         /// <returns><b>The hotloaded assembly</b> if found; otherwise, <b>null</b>.</returns>
+        [Obsolete("Use " + nameof(FindAssembly) + " method instead")]
         public static Assembly? GetAssembly(string fullname)
         {
-            if (s_Assemblies.TryGetValue(fullname, out var assembly))
+            return FindAssembly(new AssemblyName(fullname));
+        }
+
+        /// <summary>
+        /// Resolves a hotloaded assembly. Hotloaded assemblies have an auto generated assembly name.
+        /// </summary>
+        /// <param name="name">The assembly name to resolve.</param>
+        /// <returns><b>The hotloaded assembly</b> if found; otherwise, <b>null</b>.</returns>
+        public static Assembly? FindAssembly(AssemblyName name)
+        {
+            if (s_Assemblies.TryGetValue(name, out var assembly))
             {
                 return assembly;
-            }
-
-            var name = ReflectionExtensions.GetVersionIndependentName(fullname);
-
-            foreach (var kv in s_Assemblies)
-            {
-                if (ReflectionExtensions.GetVersionIndependentName(kv.Key).Equals(name))
-                {
-                    return kv.Value;
-                }
             }
 
             return null;
@@ -151,7 +185,7 @@ namespace OpenMod.Common.Hotloading
             {
                 if (kv.Value == assembly)
                 {
-                    return new AssemblyName(kv.Key);
+                    return kv.Key;
                 }
             }
 

--- a/framework/OpenMod.Common/OpenMod.Common.csproj
+++ b/framework/OpenMod.Common/OpenMod.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dnlib" Version="3.5.0" />
+    <PackageReference Include="AsmResolver.PE" Version="5.3.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/framework/OpenMod.NuGet/NuGetAssembly.cs
+++ b/framework/OpenMod.NuGet/NuGetAssembly.cs
@@ -1,12 +1,26 @@
 ﻿using System;
+using System.Reflection;
 using NuGet.Packaging.Core;
 
 namespace OpenMod.NuGet
 {
     public sealed class NuGetAssembly
     {
-        public string AssemblyName { get; set; } = null!;
-        public Version Version { get; set; } = null!;
+        [Obsolete("Use " + nameof(AssemblyName2) + ".Name")]
+        public string AssemblyName
+        {
+            get { return AssemblyName2.Name; }
+            set { /* ignore set */ }
+        }
+        public AssemblyName AssemblyName2 { get; set; } = null!;
+
+        [Obsolete("Use " + nameof(AssemblyName2) + ".Version")]
+        public Version Version
+        {
+            get { return AssemblyName2.Version; }
+            set { /* ignore set */ }
+        }
+
         public WeakReference Assembly { get; set; } = null!;
         public PackageIdentity Package { get; set; } = null!;
     }

--- a/unturned/OpenMod.Unturned/RocketMod/Commands/RocketModCommandFromOpenMod.cs
+++ b/unturned/OpenMod.Unturned/RocketMod/Commands/RocketModCommandFromOpenMod.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using dnlib.DotNet.Emit;
 using OpenMod.API.Commands;
 using Rocket.API;
 
@@ -29,7 +29,7 @@ namespace OpenMod.Unturned.RocketMod.Commands
 
         public void Execute(IRocketPlayer player, string[] command)
         {
-            throw new InvalidMethodException($"OpenmodCommand: {Name} can not be execute directly.");
+            throw new InvalidOperationException($"OpenmodCommand: {Name} can not be execute directly.");
         }
     }
 }


### PR DESCRIPTION
And using low-level API for improving performance of hotloading.

```ini
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22631.1830)
AMD Ryzen 5 1600, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8.1 (4.8.9166.0), X64 RyuJIT VectorSize=256
  DefaultJob : .NET Framework 4.8.1 (4.8.9166.0), X64 RyuJIT VectorSize=256


|                      Method |      Mean |     Error |    StdDev |      Gen0 |      Gen1 |     Gen2 | Allocated |
|---------------------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
|                  DnLibWrite | 68.020 ms | 1.0001 ms | 0.9355 ms | 4000.0000 | 1250.0000 | 125.0000 |  23.51 MB |
| AsmResolverReadAndWriteFast |  5.146 ms | 0.0774 ms | 0.0646 ms | 1843.7500 | 1117.1875 | 492.1875 |   9.15 MB |
```