### PR TITLE
Unturned event changes

### DIFF
--- a/unturned/OpenMod.Unturned/Animals/Events/UnturnedAnimalDamagingEvent.cs
+++ b/unturned/OpenMod.Unturned/Animals/Events/UnturnedAnimalDamagingEvent.cs
@@ -1,7 +1,6 @@
 ﻿using OpenMod.API.Eventing;
 using SDG.Unturned;
 using System.Numerics;
-using OpenMod.Unturned.Users;
 using Steamworks;
 
 namespace OpenMod.Unturned.Animals.Events
@@ -16,15 +15,18 @@ namespace OpenMod.Unturned.Animals.Events
         
         public CSteamID Instigator { get; set; }
 
+        public ELimb Limb { get; set; }
+
         public bool IsCancelled { get; set; }
 
         public UnturnedAnimalDamagingEvent(UnturnedAnimal animal, ushort damageAmount, Vector3 ragdoll,
-            ERagdollEffect ragdollEffect, CSteamID instigator) : base(animal)
+            ERagdollEffect ragdollEffect, CSteamID instigator, ELimb limb) : base(animal)
         {
             DamageAmount = damageAmount;
             Ragdoll = ragdoll;
             RagdollEffect = ragdollEffect;
             Instigator = instigator;
+            Limb = limb;
         }
     }
 }

--- a/unturned/OpenMod.Unturned/Animals/Events/UnturnedAnimalDyingEvent.cs
+++ b/unturned/OpenMod.Unturned/Animals/Events/UnturnedAnimalDyingEvent.cs
@@ -7,8 +7,8 @@ namespace OpenMod.Unturned.Animals.Events
     public class UnturnedAnimalDyingEvent : UnturnedAnimalDamagingEvent
     {
         public UnturnedAnimalDyingEvent(UnturnedAnimal animal, ushort damageAmount, Vector3 ragdoll,
-            ERagdollEffect ragdollEffect, CSteamID instigator) : base(animal, damageAmount, ragdoll,
-            ragdollEffect, instigator)
+            ERagdollEffect ragdollEffect, CSteamID instigator, ELimb limb) : base(animal, damageAmount, ragdoll,
+            ragdollEffect, instigator, limb)
         {
         }
     }


### PR DESCRIPTION
Fixes #721 with multiplying the damage amount with beacon damage reduction. And also removes reflection usage to get zombie region.

For animal damaging/dying events, added limb parameter and removed usage of reflection when trying to get instigator with vehicle bumper.