### PR TITLE
Fix upgrade command delete OpenMod module

### DIFF
--- a/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
+++ b/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
@@ -181,7 +181,7 @@ namespace OpenMod.Unturned.Commands
         {
             foreach (var file in Directory.GetFiles(openModDirPath))
             {
-                if (!file.EndsWith(".bak"))
+                if (file.EndsWith(".bak"))
                 {
                     continue;
                 }

--- a/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
+++ b/unturned/OpenMod.Unturned/Commands/CommandOpenModUpgrade.cs
@@ -73,7 +73,7 @@ namespace OpenMod.Unturned.Commands
 
                 try
                 {
-                    await PrintAsync($"Downloading {moduleAsset.AssetName}...");
+                    await PrintAsync($"Downloading {moduleAsset.AssetName} v{releaseVersion}...");
 
                     var stream = await client.GetStreamAsync(moduleAsset.BrowserDownloadUrl);
 


### PR DESCRIPTION
Fixes when extracting module throws an exception, that causes the upgrade command to delete OpenMod module.
And some minor changes, like show the version of downloading module.