### PR TITLE
Fix package manager installs the latest version of a package instead of the specified one

### DIFF
--- a/framework/OpenMod.Core/Plugins/NuGet/NuGetPluginAssembliesSource.cs
+++ b/framework/OpenMod.Core/Plugins/NuGet/NuGetPluginAssembliesSource.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using OpenMod.API;
 using OpenMod.API.Plugins;
 using OpenMod.NuGet;
@@ -83,7 +85,11 @@ namespace OpenMod.Core.Plugins.NuGet
                 return new NuGetInstallResult(NuGetInstallCode.PackageOrVersionNotFound);
             }
 
-            var result = await m_NuGetPackageManager.InstallAsync(package.Identity, isPreRelease);
+            var packageIdentity = version is null
+                ? package.Identity
+                : new PackageIdentity(package.Identity.Id, new NuGetVersion(version));
+
+            var result = await m_NuGetPackageManager.InstallAsync(packageIdentity, isPreRelease);
             if (result.Code is not NuGetInstallCode.Success and not NuGetInstallCode.NoUpdatesFound)
             {
                 return result;


### PR DESCRIPTION
Fixes https://github.com/openmod/openmod/issues/733

This PR reverts https://github.com/openmod/openmod/commit/959be82a3dde8563d5ef19f354f9ace0197704c9#diff-53f8f12e2513bf10e96af61fb03274ef7c10129e06b446be73a1956e51390826L95-R87