### PR TITLE
Fixed shared plugin keys states in `PlayerInputEventsListener.OnPluginKeyTick`

### DIFF
--- a/unturned/OpenMod.Unturned/Players/Input/Events/PlayerInputEventsListener.cs
+++ b/unturned/OpenMod.Unturned/Players/Input/Events/PlayerInputEventsListener.cs
@@ -1,9 +1,12 @@
 ﻿extern alias JetBrainsAnnotations;
 using System;
+using System.Collections.Generic;
 
 using OpenMod.Unturned.Events;
 
 using SDG.Unturned;
+
+using Steamworks;
 
 namespace OpenMod.Unturned.Players.Input.Events
 {
@@ -16,29 +19,45 @@ namespace OpenMod.Unturned.Players.Input.Events
 
         public override void Subscribe()
         {
+            Provider.onServerConnected += OnServerConnected;
+            Provider.onServerDisconnected += OnServerDisconnected;
             PlayerInput.onPluginKeyTick += OnPluginKeyTick;
         }
 
         public override void Unsubscribe()
         {
+            Provider.onServerConnected -= OnServerConnected;
+            Provider.onServerDisconnected -= OnServerDisconnected;
             PlayerInput.onPluginKeyTick -= OnPluginKeyTick;
         }
 
-        private readonly bool[] m_LastInputs = new bool[ControlsSettings.NUM_PLUGIN_KEYS];
+        private void OnServerConnected(CSteamID steamID)
+        {
+            m_LastInputs.Add(steamID, new bool[ControlsSettings.NUM_PLUGIN_KEYS]);
+        }
+
+        private void OnServerDisconnected(CSteamID steamID)
+        {
+            m_LastInputs.Remove(steamID);
+        }
+
+        private readonly Dictionary<CSteamID, bool[]> m_LastInputs = new();
 
         private void OnPluginKeyTick(Player nativePlayer, uint simulation, byte key, bool state)
         {
-            if (key >= m_LastInputs.Length)
+            if (key >= ControlsSettings.NUM_PLUGIN_KEYS)
             {
                 return;
             }
 
-            if (m_LastInputs[key] == state)
+            var playerSteamId = nativePlayer.channel.owner.playerID.steamID;
+
+            if (m_LastInputs[playerSteamId][key] == state)
             {
                 return;
             }
 
-            m_LastInputs[key] = state;
+            m_LastInputs[playerSteamId][key] = state;
 
             var player = GetUnturnedPlayer(nativePlayer)!;
             var @event = new UnturnedPlayerPluginKeyStateChangedEvent(player, key, state);


### PR DESCRIPTION
Fixes #745 