### PR TITLE
Add check for empty last argument in `ArgumentsParser.ParseArguments()`

### DIFF
--- a/framework/OpenMod.Core/Helpers/ArgumentsParser.cs
+++ b/framework/OpenMod.Core/Helpers/ArgumentsParser.cs
@@ -83,7 +83,9 @@ namespace OpenMod.Core.Helpers
             if (inQuote || inApostrophes) //command: 'command "player    ' -> args: 'command', 'player'
                 currentArg = TrimEnd(currentArg);
 
-            args.Add(currentArg.ToString());
+            if (currentArg.Length != 0)
+                args.Add(currentArg.ToString());
+
             return args.ToArray();
         }
 


### PR DESCRIPTION
Closes #574 