### PR TITLE
More user-friendly time formatting

### DIFF
--- a/framework/OpenMod.Core/openmod.translations.yaml
+++ b/framework/OpenMod.Core/openmod.translations.yaml
@@ -9,4 +9,4 @@
     not_found: "Command was not found: {CommandName}"
     wrong_usage: "Wrong command usage. Correct usage: {Command} {Syntax}"
     not_enough_permission: "You don't have permission '{Permission}' to execute this command"
-    cooldown: "This command is still on cooldown ({TimeLeft.TotalSeconds:F} seconds)"
+    cooldown: "This command is on cooldown for another {TimeLeft:time(en):days seconds noless auto}"

--- a/unturned/OpenMod.Unturned/openmod.unturned.translations.yaml
+++ b/unturned/OpenMod.Unturned/openmod.unturned.translations.yaml
@@ -2,4 +2,4 @@
   uconomy:
     not_enough_balance: "You don't have enough balance. Current balance: {Balance}{EconomyProvider.CurrencySymbol}"
   permissions:
-    command_cooldown: "You must wait {TimeLeft:0.##} seconds."
+    command_cooldown: "You must wait {TimeLeftSpan:time(en):days seconds less auto} to use this command again"


### PR DESCRIPTION
Someone asked for this in Discord few weeks ago.

Before: 
```
This command is still on cooldown (583.43 seconds)
```

Now:
![](https://github.com/openmod/openmod/assets/37713088/4af8b342-7a12-4296-aaa6-6e1041ae8605)
