### PR TITLE
Fix mono socket async doesn't work as expected

### DIFF
--- a/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
+++ b/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Buffers;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using HarmonyLib;
+using OpenMod.Unturned.Patching;
 
 namespace OpenMod.Unturned.Mono;
 
@@ -15,6 +18,13 @@ namespace OpenMod.Unturned.Mono;
 [HarmonyPatch]
 internal static class Patch_SocketTaskExtensions
 {
+    [HarmonyCleanup]
+    public static Exception? Cleanup(Exception ex, MethodBase original)
+    {
+        HarmonyExceptionHandler.ReportCleanupException(typeof(Patch_SocketTaskExtensions), ex, original);
+        return null;
+    }
+
     [HarmonyPatch(typeof(SocketTaskExtensions), nameof(SocketTaskExtensions.ReceiveAsync),
     new[] { typeof(Socket), typeof(Memory<byte>), typeof(SocketFlags), typeof(CancellationToken) })]
     [HarmonyPrefix]

--- a/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
+++ b/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
@@ -18,7 +18,7 @@ internal static class Patch_SocketTaskExtensions
         if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment))
         {
             var taskCompletionSource = new TaskCompletionSource<int>(socket);
-            socket.BeginReceive(segment.Array, 0, segment.Array.Length, socketFlags, iar =>
+            socket.BeginReceive(segment.Array, segment.Offset, segment.Count, socketFlags, iar =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var taskCompletionSource2 = (TaskCompletionSource<int>)iar.AsyncState;

--- a/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
+++ b/unturned/OpenMod.Unturned/Mono/Patch_SocketTaskExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using HarmonyLib;
+
+namespace OpenMod.Unturned.Mono;
+[HarmonyPatch]
+internal static class Patch_SocketTaskExtensions
+{
+    [HarmonyPatch(typeof(SocketTaskExtensions), nameof(SocketTaskExtensions.ReceiveAsync),
+    new[] { typeof(Socket), typeof(Memory<byte>), typeof(SocketFlags), typeof(CancellationToken) })]
+    [HarmonyPrefix]
+    public static bool SocketTaskExtensionsReceiveAsync(Socket socket, Memory<byte> memory, SocketFlags socketFlags, CancellationToken cancellationToken,
+        out ValueTask<int> __result)
+    {
+        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment))
+        {
+            var taskCompletionSource = new TaskCompletionSource<int>(socket);
+            socket.BeginReceive(segment.Array, 0, segment.Array.Length, socketFlags, iar =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var taskCompletionSource2 = (TaskCompletionSource<int>)iar.AsyncState;
+                var socket2 = (Socket)taskCompletionSource2.Task.AsyncState;
+                try
+                {
+                    taskCompletionSource2.TrySetResult(socket2.EndReceive(iar));
+                }
+                catch (Exception ex)
+                {
+                    taskCompletionSource2.TrySetException(ex);
+                }
+            }, taskCompletionSource);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            __result = new ValueTask<int>(taskCompletionSource.Task);
+        }
+        else
+        {
+            __result = new(0);
+        }
+
+        return false;
+    }
+}

--- a/unturned/OpenMod.Unturned/Patching/HarmonyExceptionHandler.cs
+++ b/unturned/OpenMod.Unturned/Patching/HarmonyExceptionHandler.cs
@@ -25,7 +25,7 @@ namespace OpenMod.Unturned.Patching
 
             var logger = loggerFactory.CreateLogger("OpenMod.Harmony");
             logger.LogError(exception, "Failed to patch original method {MethodName} from patching type {TypeName}",
-                originalMethod?.FullDescription(), type.FullDescription());
+                originalMethod.FullDescription(), type.FullDescription());
         }
     }
 }


### PR DESCRIPTION
Patching `SocketTaskExtensions.ReceiveAsync` allows using async methods without any bugs.

