### PR TITLE
Fix FileSystemWatcher CPU usage on Mono

### DIFF
--- a/framework/OpenMod.Core/Configuration/YamlConfigurationExtensions.cs
+++ b/framework/OpenMod.Core/Configuration/YamlConfigurationExtensions.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Extensions.Configuration
                 s.Path = path;
                 s.Optional = optional;
                 s.ReloadOnChange = reloadOnChange;
-                s.ResolveFileProvider();
                 s.Variables = variables;
+                s.ResolveFileProvider();
             });
         }
 

--- a/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizer.cs
+++ b/framework/OpenMod.Core/Localization/ConfigurationBasedStringLocalizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
@@ -9,7 +10,7 @@ using OpenMod.API;
 namespace OpenMod.Core.Localization
 {
     [OpenModInternal]
-    public class ConfigurationBasedStringLocalizer : IStringLocalizer
+    public class ConfigurationBasedStringLocalizer : IStringLocalizer, IDisposable
     {
         private readonly IConfiguration m_Configuration;
         private readonly IOptions<SmartFormatOptions> m_Options;
@@ -70,6 +71,11 @@ namespace OpenMod.Core.Localization
                 var formatter = m_Options.Value.GetSmartFormatter();
                 return new LocalizedString(name, formatter.Format(configValue.Value ?? string.Empty, arguments));
             }
+        }
+
+        public void Dispose()
+        {
+            (m_Configuration as IDisposable)?.Dispose();
         }
     }
 }

--- a/framework/OpenMod.Core/Localization/ProxyStringLocalizer.cs
+++ b/framework/OpenMod.Core/Localization/ProxyStringLocalizer.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.Extensions.Localization;
 using OpenMod.API;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
 namespace OpenMod.Core.Localization
 {
     [OpenModInternal]
-    public class ProxyStringLocalizer : IStringLocalizer
+    public class ProxyStringLocalizer : IStringLocalizer, IDisposable
     {
         private readonly IStringLocalizer m_StringLocalizer;
 
@@ -23,7 +24,7 @@ namespace OpenMod.Core.Localization
 #pragma warning disable 618 // disable obsolete warning
         public IStringLocalizer WithCulture(CultureInfo culture)
         {
-            return m_StringLocalizer.WithCulture(culture); // lgtm [cs/call-to-obsolete-method]
+            return m_StringLocalizer.WithCulture(culture);
         }
 #pragma warning restore 618
 
@@ -35,6 +36,11 @@ namespace OpenMod.Core.Localization
         public LocalizedString this[string name, params object[] arguments]
         {
             get { return m_StringLocalizer[name, arguments]; }
+        }
+
+        public void Dispose()
+        {
+            (m_StringLocalizer as IDisposable)?.Dispose();
         }
     }
 }

--- a/framework/OpenMod.Runtime/OpenModStartupContext.cs
+++ b/framework/OpenMod.Runtime/OpenModStartupContext.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenMod.API;
 using OpenMod.API.Ioc;
@@ -11,6 +13,7 @@ namespace OpenMod.Runtime
     public sealed class OpenModStartupContext : IOpenModServiceConfigurationContext
     {
         public IRuntime Runtime { get; internal set; } = null!;
+        [Obsolete("Use " + nameof(HostBuilderContext) + "." + nameof(HostBuilderContext.Configuration))]
         public IConfigurationRoot Configuration { get; internal set; } = null!;
         public IOpenModStartup OpenModStartup { get; internal set; } = null!;
         public NuGetPackageManager NuGetPackageManager { get; internal set; } = null!;

--- a/unturned/OpenMod.Unturned/Configuration/OpenModUnturnedConfiguration.cs
+++ b/unturned/OpenMod.Unturned/Configuration/OpenModUnturnedConfiguration.cs
@@ -1,15 +1,13 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace OpenMod.Unturned.Configuration
 {
     public class OpenModUnturnedConfiguration : IOpenModUnturnedConfiguration
     {
-        public OpenModUnturnedConfiguration(string workingDirectory)
+        public OpenModUnturnedConfiguration(HostBuilderContext context)
         {
-            Configuration = new ConfigurationBuilder()
-                .SetBasePath(workingDirectory)
-                .AddYamlFile("openmod.unturned.yaml", optional: false, reloadOnChange: true)
-                .Build();
+            Configuration = context.Configuration;
         }
 
         public IConfiguration Configuration { get; }

--- a/unturned/OpenMod.Unturned/ConfigurationConfigurator.cs
+++ b/unturned/OpenMod.Unturned/ConfigurationConfigurator.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Configuration;
+using OpenMod.API.Ioc;
+
+namespace OpenMod.Unturned;
+internal class ConfigurationConfigurator : IConfigurationConfigurator
+{
+    public void ConfigureConfiguration(IOpenModServiceConfigurationContext openModStartupContext, IConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.AddYamlFile("openmod.unturned.yaml", optional: false, reloadOnChange: true);
+    }
+}

--- a/unturned/OpenMod.Unturned/ServiceConfigurator.cs
+++ b/unturned/OpenMod.Unturned/ServiceConfigurator.cs
@@ -3,6 +3,7 @@ using Autofac;
 using JetBrainsAnnotations::JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenMod.API;
 using OpenMod.API.Ioc;
@@ -35,7 +36,7 @@ namespace OpenMod.Unturned
             IServiceCollection serviceCollection)
         {
             var unturnedConfiguration =
-                new OpenModUnturnedConfiguration(openModStartupContext.Runtime.WorkingDirectory);
+                new OpenModUnturnedConfiguration((HostBuilderContext)openModStartupContext.DataStore["HostBuilderContext"]);
 
             serviceCollection.AddSingleton<IOpenModUnturnedConfiguration>(unturnedConfiguration);
 


### PR DESCRIPTION
Note, it's only fixed on Windows, for Linux I have only added logging to see if it for some reason using the managed watcher, instead of `inotify`. Probably closes https://github.com/openmod/openmod/pull/758

And some other changes:
- `IConfigurationConfigurator` is now called once, for less overhead.
- Plugins can now get `HostBuilderContext` via `Context.DataStore["HostBuilderContext"]`.
- Obsolete `Context.Configuration` to use instead `HostBuilderContext.Configuration`.
- `IStringLocalizer` are now disposed on shutdown.



