### PR TITLE
Add YAML `System.Numerics.Vector3` converter

### DIFF
--- a/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
+++ b/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
@@ -6,6 +6,12 @@ namespace OpenMod.Core.Persistence;
 
 public class YamlDataStoreOptions
 {
+    public IReadOnlyList<IYamlTypeConverter> Converters {
+        get {
+            return m_Converters.AsReadOnly();
+        }
+    }
+
     private readonly List<IYamlTypeConverter> m_Converters;
 
     public YamlDataStoreOptions()

--- a/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
+++ b/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Serialization;
+
+namespace OpenMod.Core.Persistence;
+
+public class YamlDataStoreOptions
+{
+    private readonly List<IYamlTypeConverter> m_Converters;
+
+    public YamlDataStoreOptions()
+    {
+        m_Converters = new List<IYamlTypeConverter>();
+    }
+
+    /// <summary>
+    /// Adds the specified <see cref="IYamlTypeConverter"/> to the converters list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns><see langword="true"/> if the converter is added to converters list; <see langword="false"/> if the converter is already present.</returns>
+    public bool TryAddConverter<T>() where T : class, IYamlTypeConverter, new()
+    {
+        if (m_Converters.Any(c => c.GetType() == typeof(T)))
+        {
+            return false;
+        }
+
+        m_Converters.Add(new T());
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the specified <see cref="IYamlTypeConverter"/> from the converters list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns><see langword="true"/> if the converter is successfully found and removed; otherwise, <see langword="false"/>.</returns>
+    public bool TryRemoveConverter<T>() where T : class, IYamlTypeConverter, new()
+    {
+        var indexOfConverter = m_Converters.FindIndex(c => c.GetType() == typeof(T));
+
+        if (indexOfConverter == -1)
+        {
+            return false;
+        }
+
+        m_Converters.RemoveAt(indexOfConverter);
+        return true;
+    }
+}

--- a/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
+++ b/framework/OpenMod.Core/Persistence/YamlDataStoreOptions.cs
@@ -6,8 +6,10 @@ namespace OpenMod.Core.Persistence;
 
 public class YamlDataStoreOptions
 {
-    public IReadOnlyList<IYamlTypeConverter> Converters {
-        get {
+    public IReadOnlyList<IYamlTypeConverter> Converters
+    {
+        get
+        {
             return m_Converters.AsReadOnly();
         }
     }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -1,0 +1,67 @@
+﻿using OpenMod.API;
+using System;
+using System.Numerics;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace OpenMod.Core.Persistence;
+
+[OpenModInternal]
+public class Vector3YamlConverter : IYamlTypeConverter
+{
+    public bool Accepts(Type type)
+    {
+        return type == typeof(Vector3);
+    }
+
+    public object ReadYaml(IParser parser, Type type)
+    {
+        if (!parser.TryConsume<MappingStart>(out _))
+        {
+            throw new InvalidOperationException("Invalid Vector3 format in YAML.");
+        }
+
+        float x = 0, y = 0, z = 0;
+
+        while (!parser.TryConsume<MappingEnd>(out _))
+        {
+            var key = parser.Consume<Scalar>();
+            var value = parser.Consume<Scalar>();
+
+            switch (key.Value)
+            {
+                case "X":
+                    x = float.Parse(value.Value);
+                    break;
+                case "Y":
+                    y = float.Parse(value.Value);
+                    break;
+                case "Z":
+                    z = float.Parse(value.Value);
+                    break;
+            }
+        }
+
+        return new Vector3(x, y, z);
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        var vector = (Vector3)value;
+
+        emitter.Emit(new MappingStart());
+        emitter.Emit(new Scalar("X"));
+        emitter.Emit(new Scalar(vector.X.ToString()));
+        emitter.Emit(new Scalar("Y"));
+        emitter.Emit(new Scalar(vector.Y.ToString()));
+        emitter.Emit(new Scalar("Z"));
+        emitter.Emit(new Scalar(vector.Z.ToString()));
+        emitter.Emit(new MappingEnd());
+    }
+}

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -10,16 +10,22 @@ namespace OpenMod.Core.Persistence;
 [OpenModInternal]
 public class YamlVector3TypeConverter : IYamlTypeConverter
 {
+    private const string c_YamlKeyOfX = "x";
+
+    private const string c_YamlKeyOfY = "y";
+
+    private const string c_YamlKeyOfZ = "z";
+
     public bool Accepts(Type type)
     {
         return type == typeof(Vector3);
     }
 
-    public object ReadYaml(IParser parser, Type type)
+    public object? ReadYaml(IParser parser, Type type)
     {
         if (!parser.TryConsume<MappingStart>(out _))
         {
-            throw new InvalidOperationException("Invalid Vector3 format in YAML.");
+            throw new InvalidOperationException("Invalid Vector3 format in YAML");
         }
 
         float x = 0, y = 0, z = 0;
@@ -31,13 +37,13 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
 
             switch (key.Value)
             {
-                case "X":
+                case c_YamlKeyOfX:
                     x = float.Parse(value.Value);
                     break;
-                case "Y":
+                case c_YamlKeyOfY:
                     y = float.Parse(value.Value);
                     break;
-                case "Z":
+                case c_YamlKeyOfZ:
                     z = float.Parse(value.Value);
                     break;
             }
@@ -56,12 +62,16 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
         var vector = (Vector3)value;
 
         emitter.Emit(new MappingStart());
-        emitter.Emit(new Scalar("X"));
+
+        emitter.Emit(new Scalar(c_YamlKeyOfX));
         emitter.Emit(new Scalar(vector.X.ToString()));
-        emitter.Emit(new Scalar("Y"));
+
+        emitter.Emit(new Scalar(c_YamlKeyOfY));
         emitter.Emit(new Scalar(vector.Y.ToString()));
-        emitter.Emit(new Scalar("Z"));
+
+        emitter.Emit(new Scalar(c_YamlKeyOfZ));
         emitter.Emit(new Scalar(vector.Z.ToString()));
+
         emitter.Emit(new MappingEnd());
     }
 }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -35,13 +35,13 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
             switch (key.Value)
             {
                 case c_YamlKeyOfX:
-                    x = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
+                    x = float.Parse(value.Value);
                     break;
                 case c_YamlKeyOfY:
-                    y = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
+                    y = float.Parse(value.Value);
                     break;
                 case c_YamlKeyOfZ:
-                    z = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
+                    z = float.Parse(value.Value);
                     break;
             }
         }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -35,13 +35,13 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
             switch (key.Value)
             {
                 case c_YamlKeyOfX:
-                    x = float.Parse(value.Value);
+                    x = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
                     break;
                 case c_YamlKeyOfY:
-                    y = float.Parse(value.Value);
+                    y = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
                     break;
                 case c_YamlKeyOfZ:
-                    z = float.Parse(value.Value);
+                    z = float.Parse(value.Value, YamlFormatter.Default.NumberFormat);
                     break;
             }
         }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -23,10 +23,7 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
 
     public object? ReadYaml(IParser parser, Type type)
     {
-        if (!parser.TryConsume<MappingStart>(out _))
-        {
-            throw new InvalidOperationException("Invalid Vector3 format in YAML");
-        }
+        parser.Consume<MappingStart>();
 
         float x = 0, y = 0, z = 0;
 

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -23,6 +23,11 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
 
     public object? ReadYaml(IParser parser, Type type)
     {
+        static float ParseNumber(Scalar scalar)
+        {
+            return float.Parse(scalar.Value, YamlFormatter.Default.NumberFormat);
+        }
+
         parser.Consume<MappingStart>();
 
         float x = 0, y = 0, z = 0;
@@ -35,13 +40,13 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
             switch (key.Value)
             {
                 case c_YamlKeyOfX:
-                    x = float.Parse(value.Value);
+                    x = ParseNumber(value);
                     break;
                 case c_YamlKeyOfY:
-                    y = float.Parse(value.Value);
+                    y = ParseNumber(value);
                     break;
                 case c_YamlKeyOfZ:
-                    z = float.Parse(value.Value);
+                    z = ParseNumber(value);
                     break;
             }
         }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -58,7 +58,7 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
     {
         if (value == null)
         {
-            return;
+            throw new NullReferenceException(nameof(value));
         }
 
         var vector = (Vector3)value;

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -56,6 +56,11 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object? value, Type type)
     {
+        static string FormatNumber(float number)
+        {
+            return YamlFormatter.Default.FormatNumber(number);
+        }
+
         if (value == null)
         {
             throw new NullReferenceException(nameof(value));
@@ -66,13 +71,13 @@ public class YamlVector3TypeConverter : IYamlTypeConverter
         emitter.Emit(new MappingStart());
 
         emitter.Emit(new Scalar(c_YamlKeyOfX));
-        emitter.Emit(new Scalar(vector.X.ToString()));
+        emitter.Emit(new Scalar(FormatNumber(vector.X)));
 
         emitter.Emit(new Scalar(c_YamlKeyOfY));
-        emitter.Emit(new Scalar(vector.Y.ToString()));
+        emitter.Emit(new Scalar(FormatNumber(vector.Y)));
 
         emitter.Emit(new Scalar(c_YamlKeyOfZ));
-        emitter.Emit(new Scalar(vector.Z.ToString()));
+        emitter.Emit(new Scalar(FormatNumber(vector.Z)));
 
         emitter.Emit(new MappingEnd());
     }

--- a/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
+++ b/framework/OpenMod.Core/Persistence/YamlVector3TypeConverter.cs
@@ -8,7 +8,7 @@ using YamlDotNet.Serialization;
 namespace OpenMod.Core.Persistence;
 
 [OpenModInternal]
-public class Vector3YamlConverter : IYamlTypeConverter
+public class YamlVector3TypeConverter : IYamlTypeConverter
 {
     public bool Accepts(Type type)
     {

--- a/framework/OpenMod.Core/ServiceConfigurator.cs
+++ b/framework/OpenMod.Core/ServiceConfigurator.cs
@@ -14,6 +14,7 @@ using OpenMod.Core.Users;
 using System;
 using OpenMod.Core.Jobs;
 using SmartFormat.Extensions;
+using OpenMod.Core.Persistence;
 
 namespace OpenMod.Core
 {
@@ -56,6 +57,12 @@ namespace OpenMod.Core
             serviceCollection.Configure<SmartFormatOptions>(options =>
             {
                 options.TryAddFormatter<TimeFormatter>();
+            });
+
+            serviceCollection.Configure<YamlDataStoreOptions>(options =>
+            {
+                options.TryAddConverter<YamlNullableEnumTypeConverter>();
+                options.TryAddConverter<YamlVector3TypeConverter>();
             });
 
             serviceCollection.AddTransient<IStringLocalizerFactory, ConfigurationBasedStringLocalizerFactory>();

--- a/framework/OpenMod.Core/ServiceConfigurator.cs
+++ b/framework/OpenMod.Core/ServiceConfigurator.cs
@@ -15,7 +15,6 @@ using System;
 using OpenMod.Core.Jobs;
 using SmartFormat.Extensions;
 using OpenMod.Core.Persistence;
-using Microsoft.Extensions.Configuration;
 
 namespace OpenMod.Core
 {
@@ -63,13 +62,7 @@ namespace OpenMod.Core
             serviceCollection.Configure<YamlDataStoreOptions>(options =>
             {
                 options.TryAddConverter<YamlNullableEnumTypeConverter>();
-
-                var shouldAddVector3Converter = openModStartupContext.Configuration.GetSection("yaml:enableVector3Converter").Get<bool>();
-
-                if (shouldAddVector3Converter)
-                {
-                    options.TryAddConverter<YamlVector3TypeConverter>();
-                }
+                options.TryAddConverter<YamlVector3TypeConverter>();
             });
 
             serviceCollection.AddTransient<IStringLocalizerFactory, ConfigurationBasedStringLocalizerFactory>();

--- a/framework/OpenMod.Core/ServiceConfigurator.cs
+++ b/framework/OpenMod.Core/ServiceConfigurator.cs
@@ -15,6 +15,7 @@ using System;
 using OpenMod.Core.Jobs;
 using SmartFormat.Extensions;
 using OpenMod.Core.Persistence;
+using Microsoft.Extensions.Configuration;
 
 namespace OpenMod.Core
 {
@@ -62,7 +63,13 @@ namespace OpenMod.Core
             serviceCollection.Configure<YamlDataStoreOptions>(options =>
             {
                 options.TryAddConverter<YamlNullableEnumTypeConverter>();
-                options.TryAddConverter<YamlVector3TypeConverter>();
+
+                var shouldAddVector3Converter = openModStartupContext.Configuration.GetSection("yaml:enableVector3Converter").Get<bool>();
+
+                if (shouldAddVector3Converter)
+                {
+                    options.TryAddConverter<YamlVector3TypeConverter>();
+                }
             });
 
             serviceCollection.AddTransient<IStringLocalizerFactory, ConfigurationBasedStringLocalizerFactory>();

--- a/framework/OpenMod.Core/openmod.yaml
+++ b/framework/OpenMod.Core/openmod.yaml
@@ -10,6 +10,11 @@ console:
 cooldowns:
   reloadPersistence: true
 
+# YAML related configurations
+yaml:
+  # Enables System.Numerics.Vector3 conversion in YAML data stores  
+  enableVector3Converter: true
+
 # NuGet related configurations. See packages/NuGet.Config for more configuration options such as feeds to use.
 nuget:
   # The following OpenMod commands are restricted to some users even if they have permissions.

--- a/framework/OpenMod.Core/openmod.yaml
+++ b/framework/OpenMod.Core/openmod.yaml
@@ -10,11 +10,6 @@ console:
 cooldowns:
   reloadPersistence: true
 
-# YAML related configurations
-yaml:
-  # Enables System.Numerics.Vector3 conversion in YAML data stores  
-  enableVector3Converter: true
-
 # NuGet related configurations. See packages/NuGet.Config for more configuration options such as feeds to use.
 nuget:
   # The following OpenMod commands are restricted to some users even if they have permissions.


### PR DESCRIPTION
Closes #759 

Let's say we have a vector:

```cs
var vector3 = new System.Numerics.Vector3(1.234f, -11.05f, 100);
```

Then it'll be serialized into:

```yaml
vector:
  x: 1,234
  y: -11,05
  z: 100

```