### PR TITLE
Trim extra zeros in vehicle state

### DIFF
--- a/unturned/OpenMod.Unturned/Vehicles/UnturnedVehicleState.cs
+++ b/unturned/OpenMod.Unturned/Vehicles/UnturnedVehicleState.cs
@@ -113,7 +113,9 @@ namespace OpenMod.Unturned.Vehicles
                 writer.Write((byte)255);
                 writer.Flush();
 
+                stream.SetLength(stream.Position);
                 var stateData = stream.ToArray();
+
                 ArrayPool<byte>.Shared.Return(buffer);
 
                 return stateData;


### PR DESCRIPTION
Fixes #780 
![image](https://github.com/openmod/openmod/assets/20555316/55716ffc-5e50-4a2b-9fa5-bc55c6db881a)
When we read Vehicle state we look for 255 at end for compatibility
![image](https://github.com/openmod/openmod/assets/20555316/9c85a897-72e3-48b4-bce0-1bdee2842636)
