### PR TITLE
Strange tables format at documentation 

### DIFF
--- a/docs/userdoc/concepts/jobs.md
+++ b/docs/userdoc/concepts/jobs.md
@@ -28,6 +28,7 @@ Schedule defines when a job will run. There are several ways to do it.
 A one-time scheduling allows to define the conditions under which a job will be executed.
 
 Below are the `schedule` types that define required conditions.
+
 | Type         | Description                                                                          |
 |--------------|------------------------------------------------------------------------------------- |
 | @startup     | Executes a job after OpenMod and all plugins have loaded, including reloads.         |
@@ -37,6 +38,7 @@ Below are the `schedule` types that define required conditions.
 You can also delay execution of one-time scheduled job. Delayed job `schedule` template should look as further: `<schedule type>:<delay>`. 
 
 Here are some examples of delayed job `schedule`.
+
 | Example schedule template                   | Description                                                                                                                  |
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------- |
 | @startup:20 seconds                         | Executes a job 20 seconds after OpenMod and all plugins have loaded, including reloads.                                      |
@@ -49,6 +51,7 @@ Here are some examples of delayed job `schedule`.
 For periodical scheduling OpenMod uses **crontab expressions**. It allows to execute a job at fixed intervals, like every minute, every Sunday, every third Monday, etc. Visit https://crontab.guru/ for more information. 
 
 Here are some example crontab expressions.
+
 | Expression  | Description                                 |
 |-------------|---------------------------------------------|
 | 0 0 * * 0   | Every Sunday at 0:00 AM.                    |
@@ -57,7 +60,8 @@ Here are some example crontab expressions.
 | 0 0 1 * *   | At the first day of every month at 0:00 AM. |
 
 ## Task
-The task to execute. There are 2 built-in tasks:
+The task to execute. There are 2 built-in tasks.
+
 | Task type       | Description                                                               |
 |-----------------|---------------------------------------------------------------------------|
 | openmod_command | Executes one or more OpenMod commands. Needs args.commands to be defined. |

--- a/docs/userdoc/concepts/jobs.md
+++ b/docs/userdoc/concepts/jobs.md
@@ -29,7 +29,7 @@ A one-time scheduling allows to define the conditions under which a job will be 
 
 Below are the `schedule` types that define required conditions.
 
-| Type         | Description                                                                          |
+| **Type**     | **Description**                                                                      |
 |--------------|------------------------------------------------------------------------------------- |
 | @startup     | Executes a job after OpenMod and all plugins have loaded, including reloads.         |
 | @reboot      | Executes a job after OpenMod and all plugins have loaded, excluding reloads.         |
@@ -39,12 +39,12 @@ You can also delay execution of one-time scheduled job. Delayed job `schedule` t
 
 Here are some examples of delayed job `schedule`.
 
-| Example schedule template                   | Description                                                                                                                  |
+| **Example schedule template**               | **Description**                                                                                                              |
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------- |
 | @startup:20 seconds                         | Executes a job 20 seconds after OpenMod and all plugins have loaded, including reloads.                                      |
 | @reboot:30 days, 40 minutes, and 50 seconds | Executes a job 30 days, 40 minutes and 50 seconds after OpenMod and all plugins have loaded, excluding reloads.              |
 | @single_exec:10h20m30s                      | Executes a job a single time 10 hours, 20 minutes and 30 seconds after OpenMod has loaded and then removes it from the file. |
-| @startup:3.5 days                          | Executes a job 3 days and 12 hours after OpenMod and all plugins have loaded, including reloads.                             |
+| @startup:3.5 days                           | Executes a job 3 days and 12 hours after OpenMod and all plugins have loaded, including reloads.                             |
 | @single_exec:1234.123     milliseconds      | Executes a job a single time 1234.123 milliseconds after OpenMod has loaded and then removes it from the file.               |
   
 ### Periodical schedule
@@ -52,17 +52,17 @@ For periodical scheduling OpenMod uses **crontab expressions**. It allows to exe
 
 Here are some example crontab expressions.
 
-| Expression  | Description                                 |
-|-------------|---------------------------------------------|
-| 0 0 * * 0   | Every Sunday at 0:00 AM.                    |
-| 0 3 * * *   | Everyday at 3 AM.                           |
-| */5 * * * * | Every 5 minutes.                            |
-| 0 0 1 * *   | At the first day of every month at 0:00 AM. |
+| **Expression** | **Description**                             |
+|----------------|---------------------------------------------|
+| 0 0 * * 0      | Every Sunday at 0:00 AM.                    |
+| 0 3 * * *      | Everyday at 3 AM.                           |
+| */5 * * * *    | Every 5 minutes.                            |
+| 0 0 1 * *      | At the first day of every month at 0:00 AM. |
 
 ## Task
 The task to execute. There are 2 built-in tasks.
 
-| Task type       | Description                                                               |
+| **Task type**   | **Description**                                                           |
 |-----------------|---------------------------------------------------------------------------|
 | openmod_command | Executes one or more OpenMod commands. Needs args.commands to be defined. |
 | system_command  | Executes one or more system commands. Needs args.commands to be defined.  |


### PR DESCRIPTION
![image](https://github.com/openmod/openmod/assets/63493877/9a8a4faf-86f3-4dac-a9f2-5a2815a1b0ae)

My bad, seems like tables are not converted to html properly after last PR. I probably forgot to add extra line between text and table in markdown file. Just like here: https://github.com/openmod/openmod/blob/075c0dc4de6631e199ae5f9ed763708453011ce1/docs/devdoc/concepts/services.md?plain=1#L110C1-L115

New markdown file should be converted properly. Tested it out with https://markdowntohtml.com/