### PR TITLE
Jobs on event emitted

### DIFF
--- a/framework/OpenMod.API/Jobs/JobTask.cs
+++ b/framework/OpenMod.API/Jobs/JobTask.cs
@@ -8,7 +8,11 @@ namespace OpenMod.API.Jobs
     /// </summary>
     public sealed class JobTask
     {
-        public JobTask(string jobName, string task, Dictionary<string, object?> args)
+        public JobTask(string jobName, string task, Dictionary<string, object?> args) : this(jobName, task, args, Array.Empty<object>())
+        {
+        }
+
+        public JobTask(string jobName, string task, Dictionary<string, object?> args, params object[] parameters)
         {
             if (string.IsNullOrEmpty(jobName))
             {
@@ -23,6 +27,7 @@ namespace OpenMod.API.Jobs
             JobName = jobName;
             Task = task;
             Args = args ?? throw new ArgumentNullException(nameof(args));
+            Parameters = parameters;
         }
 
         /// <summary>
@@ -39,5 +44,10 @@ namespace OpenMod.API.Jobs
         /// Gets the task type.
         /// </summary>
         public string Task { get; }
+
+        /// <summary>
+        /// Gets the task parameters.
+        /// </summary>
+        public object[] Parameters { get; }
     }
 }

--- a/framework/OpenMod.Core/Jobs/JobScheduler.cs
+++ b/framework/OpenMod.Core/Jobs/JobScheduler.cs
@@ -348,7 +348,7 @@ namespace OpenMod.Core.Jobs
             var eventName = job.Schedule![(eventNameDelimiterIndex + 1)..];
 
             m_EventBus.Subscribe(m_Runtime, eventName, async (_, _, @event) => {
-                await ExecuteJobAsync(job);
+                await ExecuteJobAsync(job, new { Event = @event });
             });
 
             m_Logger.LogInformation("Subscribed job \"{JobName}\" to \"{EventName}\" event", job.Name, eventName);
@@ -413,7 +413,7 @@ namespace OpenMod.Core.Jobs
             });
         }
 
-        private async Task ExecuteJobAsync(ScheduledJob job)
+        private async Task ExecuteJobAsync(ScheduledJob job, params object[] parameters)
         {
             if (job == null)
             {
@@ -431,7 +431,7 @@ namespace OpenMod.Core.Jobs
 
             try
             {
-                await jobExecutor.ExecuteAsync(new JobTask(job.Name!, job.Task!, job.Args ?? new Dictionary<string, object?>()));
+                await jobExecutor.ExecuteAsync(new JobTask(job.Name!, job.Task!, job.Args ?? new Dictionary<string, object?>(), parameters));
             }
             catch (Exception ex)
             {

--- a/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
+++ b/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
@@ -52,7 +52,7 @@ namespace OpenMod.Core.Jobs
                 m_Logger.LogInformation("[{JobName}] Running OpenMod command: {Command}", task.JobName, command!);
 
                 var formatter = m_SmartFormatOptions.Value.GetSmartFormatter();
-                var formattedCommand = formatter.Format(command, task.Parameters);
+                var formattedCommand = formatter.Format(command!, task.Parameters);
                 var args = ArgumentsParser.ParseArguments(formattedCommand);
 
                 await m_CommandExecutor.ExecuteAsync(m_Actor, args, string.Empty);

--- a/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
+++ b/framework/OpenMod.Core/Jobs/OpenModCommandTaskExecutor.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OpenMod.API.Commands;
 using OpenMod.API.Jobs;
 using OpenMod.Core.Helpers;
+using OpenMod.Core.Localization;
 
 namespace OpenMod.Core.Jobs
 {
@@ -12,15 +14,18 @@ namespace OpenMod.Core.Jobs
     {
         private readonly ICommandExecutor m_CommandExecutor;
         private readonly ILogger<OpenModCommandTaskExecutor> m_Logger;
+        private readonly IOptions<SmartFormatOptions> m_SmartFormatOptions;
         private readonly OpenModCommandTaskActor m_Actor;
 
         public OpenModCommandTaskExecutor(
             ICommandExecutor commandExecutor,
-            ILogger<OpenModCommandTaskExecutor> logger)
+            ILogger<OpenModCommandTaskExecutor> logger,
+            IOptions<SmartFormatOptions> smartFormatOptions)
         {
             m_Actor = new OpenModCommandTaskActor(logger);
             m_CommandExecutor = commandExecutor;
             m_Logger = logger;
+            m_SmartFormatOptions = smartFormatOptions;
         }
 
         public bool SupportsType(string taskType)
@@ -36,16 +41,20 @@ namespace OpenMod.Core.Jobs
             }
 
             var commands = (IEnumerable<object?>)task.Args["commands"]!;
+
             foreach (string? command in commands)
             {
-                if(string.IsNullOrEmpty(command))
+                if (string.IsNullOrEmpty(command))
                 {
                     continue;
                 }
 
                 m_Logger.LogInformation("[{JobName}] Running OpenMod command: {Command}", task.JobName, command!);
 
-                var args = ArgumentsParser.ParseArguments(command!);
+                var formatter = m_SmartFormatOptions.Value.GetSmartFormatter();
+                var formattedCommand = formatter.Format(command, task.Parameters);
+                var args = ArgumentsParser.ParseArguments(formattedCommand);
+
                 await m_CommandExecutor.ExecuteAsync(m_Actor, args, string.Empty);
             }
         }


### PR DESCRIPTION
Closes #350 

Used `IEventBus.Subscribe(IOpenModComponent component, string eventName, EventCallback callback)` for subscription to events, which allows to be not bothered about event listener lifetime.

And `SmartFormatter` for parsing commands such as `command {Event.Player.Id}`. 

---
For testing I created example event class with two properties to access from command:
```cs
public sealed class ExampleEvent : Event
{
    public string Message { get; }

    public ulong PlayerId { get; }

    public ExampleEvent(string message, ulong playerId)
    {
        Message = message;
        PlayerId = playerId;
    }
}
```

Job configuration in `autoexec.yaml` looks as further:
```yaml
jobs:
- name: Test Event Job
  args:
    commands:
    - test_event_command {Event.Message} and {Event.PlayerId}
  task: openmod_command
  schedule: '@event:Example'
  enabled: true
```

And for emitting the event I directly called `IEventBus.EmitAsync` from Standalone project's `Program.cs` like this:
```cs
var eventBus = runtime.LifetimeScope.Resolve<IEventBus>();

if (eventBus is not null)
{
    var @event = new ExampleEvent("Hello-OpenMod!", 123456);
    
    AsyncHelper.RunSync(() => 
    {
        eventBus.EmitAsync(runtime, null, @event)
    });
}
```

---

The output is so:
![image_2023-11-18_22-58-30](https://github.com/openmod/openmod/assets/63493877/ed2927c5-e38c-42af-8152-c8d174825e23)

As you can see, parameters are being passed to the command and it's being successfully called (but was not found, obviously)

I'll also looking to write documentation. But I believe it's better to implement your corrections and merge this PR first.