### PR TITLE
Fix Harmony unpatches globally and correctly unsubscribe from `ServerCertificateValidationCallback`

### DIFF
--- a/unityengine/OpenMod.UnityEngine/ServiceConfigurator.cs
+++ b/unityengine/OpenMod.UnityEngine/ServiceConfigurator.cs
@@ -10,6 +10,7 @@ namespace OpenMod.UnityEngine
         public void ConfigureServices(IOpenModServiceConfigurationContext openModStartupContext, IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<IHostLifetime, UnityHostLifetime>();
+            serviceCollection.AddHostedService<TlsCertValidationWorkaround>();
             serviceCollection.AddHostedService<TlsHandshakeWorkaround>();
         }
     }

--- a/unityengine/OpenMod.UnityEngine/ServiceConfigurator.cs
+++ b/unityengine/OpenMod.UnityEngine/ServiceConfigurator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenMod.API.Ioc;
+using OpenMod.UnityEngine.Helpers;
 
 namespace OpenMod.UnityEngine
 {
@@ -9,6 +10,7 @@ namespace OpenMod.UnityEngine
         public void ConfigureServices(IOpenModServiceConfigurationContext openModStartupContext, IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton<IHostLifetime, UnityHostLifetime>();
+            serviceCollection.AddHostedService<TlsHandshakeWorkaround>();
         }
     }
 }

--- a/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
+++ b/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
@@ -63,7 +63,6 @@ namespace OpenMod.UnityEngine
             UniTaskScheduler.DispatchUnityMainThread = false;
 
             TlsCertValidationWorkaround.Install();
-            TlsHandshakeWorkaround.Install();
 
             Application.quitting += OnApplicationQuitting;
             Console.CancelKeyPress += OnCancelKeyPress;
@@ -108,7 +107,6 @@ namespace OpenMod.UnityEngine
             m_ShutdownBlock.Set();
 
             TlsCertValidationWorkaround.Uninstall();
-            TlsHandshakeWorkaround.Uninstall();
 
             UniTaskScheduler.UnobservedTaskException -= UniTaskExceptionHandler;
             UniTaskScheduler.DispatchUnityMainThread = true;

--- a/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
+++ b/unityengine/OpenMod.UnityEngine/UnityHostLifetime.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenMod.API;
 using OpenMod.Core.Helpers;
-using OpenMod.UnityEngine.Helpers;
 using UnityEngine;
 using UnityEngine.LowLevel;
 
@@ -62,8 +61,6 @@ namespace OpenMod.UnityEngine
             // Do not switch thread
             UniTaskScheduler.DispatchUnityMainThread = false;
 
-            TlsCertValidationWorkaround.Install();
-
             Application.quitting += OnApplicationQuitting;
             Console.CancelKeyPress += OnCancelKeyPress;
             return Task.CompletedTask;
@@ -105,8 +102,6 @@ namespace OpenMod.UnityEngine
         public void Dispose()
         {
             m_ShutdownBlock.Set();
-
-            TlsCertValidationWorkaround.Uninstall();
 
             UniTaskScheduler.UnobservedTaskException -= UniTaskExceptionHandler;
             UniTaskScheduler.DispatchUnityMainThread = true;


### PR DESCRIPTION
Refactored those classes to be registered as hosted services to avoid statics. I hope this won't break something again