### PR TITLE
Update Unturned to also target net48

### DIFF
--- a/unturned/redist/OpenMod.Unturned.Redist.nuspec
+++ b/unturned/redist/OpenMod.Unturned.Redist.nuspec
@@ -11,6 +11,8 @@
   <files>
     <file src="*.dll" target="lib\netstandard2.1" />
     <file src="*.xml" target="lib\netstandard2.1" />
+    <file src="*.dll" target="lib\net48"/>
+    <file src="*.xml" target="lib\net48"/>
     <file src="LICENSE.txt" target="" />
   </files>
 </package>


### PR DESCRIPTION
Since unturned bootstrap targets net48, we need unturned redist to do the same