### PR TITLE
added db:defaultConnectionStringName parameter

### DIFF
--- a/framework/OpenMod.Core/openmod.yaml
+++ b/framework/OpenMod.Core/openmod.yaml
@@ -35,6 +35,9 @@ nuget:
   # Try to automatically install missing plugin dependencies
   tryAutoInstallMissingDependencies: false
 
+db:
+  defaultConnectionStringName: default
+
 # RCON related configurations
 rcon:
   # Use 0.0.0.0 if you want to allow anyone to connect to RCON. This will make RCON listen on all interfaces.


### PR DESCRIPTION
db:defaultConnectionStringName parameter in **openmod.yaml** allows you to set a custom connection string name for all plugins instead of 'default'.
For example, make all plugins use **'db:ConnectionStrings:test'** instead of **'db:ConnectionStrings:default'**.