### PR TITLE
Fix: Adds IOpenModHost disposal before services are disposed of

### DIFF
--- a/framework/OpenMod.Runtime/Runtime.cs
+++ b/framework/OpenMod.Runtime/Runtime.cs
@@ -664,6 +664,13 @@ namespace OpenMod.Runtime
 
             if (Host is not null)
             {
+                IOpenModHost openModHost = LifetimeScope.Resolve<IOpenModHost>();
+
+                if (openModHost is not null)
+                {
+                    await openModHost.DisposeSyncOrAsync();
+                }
+
                 await Host.DisposeSyncOrAsync();
                 Host = null;
             }

--- a/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
+++ b/unturned/OpenMod.Unturned/OpenModUnturnedHost.cs
@@ -302,6 +302,7 @@ namespace OpenMod.Unturned
             }
 
             UnbindUnturnedEvents();
+            m_UnturnedCommandHandler.Value.Unsubscribe();
         }
     }
 }


### PR DESCRIPTION
Fixes #859
I guess this is not the right solution, but it worked for me without problems in tests with "/om reload" and "/om reload --hard"